### PR TITLE
Issue #4: Basic vote window

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,15 +4,16 @@
 `PoC`
 
 ## Recently Completed
+- #4 — PoC: Basic Vote Window: typed event queue, 10s vote window, KNOWN_STATES registry, game start/end announcements, live-tested state_types
 - #3 — PoC: Game State Polling Loop: 1s poll of STS2MCP, state_type transitions logged, clean Ctrl+C shutdown
 - #2 — PoC Bot Implementation: bot connects to Twitch, posts "Bot is online!", pings STS2MCP API, responds to `!test`
 
 ## Active Issue
-None — #3 complete, ready for #4
+None — #4 complete, ready for #5
 
 ## Up Next
-1. #4 — PoC: Basic Vote Window
-2. #5 — PoC: First Game Action Execution
+1. #5 — PoC: First Game Action Execution
+2. #16 — Vote window: random fallback when no votes / tied (needed before #5)
 3. #6 — STS2-MenuControl Integration
 
 ## Key Decisions
@@ -23,3 +24,6 @@ None — #3 complete, ready for #4
 - No automated tests for PoC
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
+- STS2 API returns lowercase state_types (e.g. `menu`, `monster`, `card_reward`)
+- `game/events.py` typed event union is the extension point for new game notifications
+- `game/options.py` KNOWN_STATES is the living registry for state_type → vote options

--- a/bot/client.py
+++ b/bot/client.py
@@ -1,14 +1,31 @@
+import asyncio
 import logging
 
+import twitchio
 from twitchio import eventsub
 from twitchio.ext import commands
+
+from bot.vote_manager import VoteManager
+from game.api_client import STS2Client
+from game.events import GameEndedEvent, GameEvent, GameStartedEvent, VoteNeededEvent
+from game.options import options_for_state
 
 logger = logging.getLogger(__name__)
 
 
 class ChatComponent(commands.Component):
-    def __init__(self, bot: "TwitchBot") -> None:
+    def __init__(self, bot: "TwitchBot", vote_manager: VoteManager) -> None:
         self.bot = bot
+        self.vote_manager = vote_manager
+
+    @commands.Component.listener()
+    async def event_message(self, payload: twitchio.ChatMessage) -> None:
+        text = payload.text.strip()
+        if not text.startswith("!") or not self.vote_manager.is_open:
+            return
+        choice = text[1:].split()[0].lower()
+        if choice:
+            self.vote_manager.record_vote(payload.chatter.id, choice)
 
     @commands.command()
     async def test(self, ctx: commands.Context) -> None:
@@ -20,13 +37,22 @@ class ChatComponent(commands.Component):
 
 
 class TwitchBot(commands.Bot):
-    def __init__(self, config: dict) -> None:
+    def __init__(
+        self,
+        config: dict,
+        event_queue: asyncio.Queue[GameEvent],
+        game_client: STS2Client,
+    ) -> None:
         self._channel = config["twitch"]["channel"]
         self._owner_id = config["twitch"]["owner_id"]
         self._bot_token = config["twitch"]["bot_token"]
         self._bot_refresh_token = config["twitch"]["bot_refresh_token"]
         self._owner_token = config["twitch"]["owner_token"]
         self._owner_refresh_token = config["twitch"]["owner_refresh_token"]
+
+        self._event_queue = event_queue
+        self._game_client = game_client  # unused in #4; seam for #5 action execution
+        self.vote_manager = VoteManager(config["vote"]["duration_seconds"])
 
         super().__init__(
             client_id=config["twitch"]["client_id"],
@@ -42,13 +68,15 @@ class TwitchBot(commands.Bot):
         await self.add_token(self._bot_token, self._bot_refresh_token)
 
     async def setup_hook(self) -> None:
-        await self.add_component(ChatComponent(self))
+        await self.add_component(ChatComponent(self, self.vote_manager))
 
         payload = eventsub.ChatMessageSubscription(
             broadcaster_user_id=self._owner_id,
             user_id=self.bot_id,
         )
         await self.subscribe_websocket(payload=payload, as_bot=True)
+
+        asyncio.create_task(self._event_runner(), name="event-runner")
 
     async def event_ready(self) -> None:
         logger.info("Connected to Twitch as %s", self.user)
@@ -59,3 +87,55 @@ class TwitchBot(commands.Bot):
             sender=self.bot_id,
             token_for=self.bot_id,
         )
+
+    async def event_command_error(self, payload: commands.CommandErrorPayload) -> None:
+        # !1, !end, !left, etc. are not registered commands — silence the noise.
+        if isinstance(payload.exception, commands.CommandNotFound):
+            return
+        await super().event_command_error(payload)
+
+    async def _event_runner(self) -> None:
+        """Background task: dequeue GameEvents and handle each in chat."""
+        logger.info("Event runner started")
+        users = await self.fetch_users(ids=[self._owner_id])
+        broadcaster: twitchio.PartialUser = users[0]
+
+        while True:
+            try:
+                event: GameEvent = await self._event_queue.get()
+
+                if isinstance(event, GameStartedEvent):
+                    logger.info("Game started: %s", event.state.summary())
+                    await broadcaster.send_message(
+                        message="A new run has started! Type !<choice> to vote when prompted.",
+                        sender=self.bot_id,
+                        token_for=self.bot_id,
+                    )
+
+                elif isinstance(event, GameEndedEvent):
+                    logger.info("Game ended: %s", event.state.summary())
+                    await broadcaster.send_message(
+                        message="Run over! Thanks for playing.",
+                        sender=self.bot_id,
+                        token_for=self.bot_id,
+                    )
+
+                elif isinstance(event, VoteNeededEvent):
+                    options = options_for_state(event.state)
+                    winner = await self.vote_manager.run_window(
+                        broadcaster=broadcaster,
+                        bot_id=self.bot_id,
+                        options=options,
+                        state_summary=event.state.summary(),
+                    )
+                    logger.info("Vote result: %s", winner)
+                    # In #5: replace the line above with:
+                    # await self._game_client.post_action(winner)
+
+                self._event_queue.task_done()
+
+            except asyncio.CancelledError:
+                logger.info("Event runner cancelled")
+                raise
+            except Exception:
+                logger.error("Unexpected error in event runner", exc_info=True)

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -1,0 +1,90 @@
+import asyncio
+import logging
+from collections import Counter
+
+import twitchio
+
+logger = logging.getLogger(__name__)
+
+
+class VoteManager:
+    """Manages a single timed vote window in Twitch chat.
+
+    One window runs at a time. `record_vote` is a no-op when no window is open
+    or when the choice is not in the current options set.
+    """
+
+    def __init__(self, duration: float) -> None:
+        self._duration = duration
+        self._open: bool = False
+        self._votes: dict[str, str] = {}        # user_id → choice
+        self._options: frozenset[str] = frozenset()
+
+    @property
+    def is_open(self) -> bool:
+        return self._open
+
+    def record_vote(self, user_id: str, choice: str) -> None:
+        """Record or overwrite a vote. No-op if window is closed or choice is invalid."""
+        if not self._open:
+            return
+        if choice not in self._options:
+            return
+        prev = self._votes.get(user_id)
+        self._votes[user_id] = choice
+        if prev and prev != choice:
+            logger.debug("User %s changed vote: %s → %s", user_id, prev, choice)
+        else:
+            logger.debug("User %s voted: %s", user_id, choice)
+
+    async def run_window(
+        self,
+        broadcaster: twitchio.PartialUser,
+        bot_id: str,
+        options: list[str],
+        state_summary: str,
+    ) -> str | None:
+        """Open a vote window, collect votes, tally, announce winner.
+
+        Returns the winning choice string, or None if no votes were cast.
+        """
+        self._votes = {}
+        self._options = frozenset(options)
+        self._open = True
+        logger.info("Vote window opened for state: %s", state_summary)
+
+        options_str = " | ".join(f"!{o}" for o in options)
+        await broadcaster.send_message(
+            message=f"Vote open! Type: {options_str}  ({self._duration:.0f}s)",
+            sender=bot_id,
+            token_for=bot_id,
+        )
+
+        await asyncio.sleep(self._duration)
+
+        self._open = False
+        logger.info("Vote window closed. %d vote(s) cast.", len(self._votes))
+
+        winner = self._tally()
+
+        if winner is None:
+            await broadcaster.send_message(
+                message="Vote closed — no votes received.",
+                sender=bot_id,
+                token_for=bot_id,
+            )
+        else:
+            count = sum(1 for v in self._votes.values() if v == winner)
+            await broadcaster.send_message(
+                message=f"Vote closed! Winner: !{winner} ({count} vote(s)).",
+                sender=bot_id,
+                token_for=bot_id,
+            )
+
+        return winner
+
+    def _tally(self) -> str | None:
+        if not self._votes:
+            return None
+        counts = Counter(self._votes.values())
+        return counts.most_common(1)[0][0]

--- a/game/events.py
+++ b/game/events.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from game.state import GameState
+
+
+@dataclass
+class VoteNeededEvent:
+    """Emitted when the game transitions to a state requiring a player decision."""
+    state: GameState
+
+
+@dataclass
+class GameStartedEvent:
+    """Emitted when the game transitions from MENU into an active run."""
+    state: GameState
+
+
+@dataclass
+class GameEndedEvent:
+    """Emitted when the game reaches GAME_OVER."""
+    state: GameState
+
+
+GameEvent = VoteNeededEvent | GameStartedEvent | GameEndedEvent

--- a/game/options.py
+++ b/game/options.py
@@ -1,0 +1,34 @@
+import logging
+
+from game.state import GameState
+
+logger = logging.getLogger(__name__)
+
+# Living registry of state_type → vote options.
+# During live testing, unknown state_types surface as WARNING logs with instructions
+# to add them here. In 1.0, values will be replaced with real API-derived options.
+KNOWN_STATES: dict[str, list[str]] = {
+    "monster":     ["1", "2", "3", "4", "5", "end"],  # combat encounter
+    "hand_select": ["1", "2", "3", "4", "5"],          # select a card from hand (card effect)
+    "card_reward": ["1", "2", "3"],
+    "map":         ["left", "right"],
+    "event":       ["1", "2", "3"],
+}
+
+
+def options_for_state(state: GameState) -> list[str]:
+    """Return the list of valid vote choices for the given game state.
+
+    If the state_type is unrecognised, logs a warning and returns a generic
+    fallback so voting is never completely blocked. Add new state_types to
+    KNOWN_STATES in this module as they are discovered through live testing.
+    """
+    options = KNOWN_STATES.get(state.state_type)
+    if options is None:
+        logger.warning(
+            "Unknown state_type '%s' — using fallback options. "
+            "Add this state to KNOWN_STATES in game/options.py.",
+            state.state_type,
+        )
+        return ["1", "2", "3"]
+    return options

--- a/game/polling.py
+++ b/game/polling.py
@@ -2,13 +2,18 @@ import asyncio
 import logging
 
 from game.api_client import STS2Client
+from game.events import GameEndedEvent, GameStartedEvent, GameEvent, VoteNeededEvent
 from game.state import GameState
 
 logger = logging.getLogger(__name__)
 
 
-async def poll_game_state(client: STS2Client, interval: float) -> None:
-    """Poll STS2MCP every `interval` seconds and log state_type transitions."""
+async def poll_game_state(
+    client: STS2Client,
+    interval: float,
+    event_queue: asyncio.Queue[GameEvent],
+) -> None:
+    """Poll STS2MCP every `interval` seconds and emit typed GameEvents on state transitions."""
     previous_state_type: str | None = None
     api_reachable: bool = True
 
@@ -26,6 +31,13 @@ async def poll_game_state(client: STS2Client, interval: float) -> None:
                 state = GameState.from_api_response(data)
                 if state.state_type != previous_state_type:
                     logger.info("Game state changed: %s", state.summary())
+                    if previous_state_type == "menu" and state.state_type != "menu":
+                        event_queue.put_nowait(GameStartedEvent(state))
+                    elif state.state_type == "game_over":
+                        event_queue.put_nowait(GameEndedEvent(state))
+                    elif state.requires_player_input():
+                        logger.info("Queuing vote for state: %s", state.state_type)
+                        event_queue.put_nowait(VoteNeededEvent(state))
                     previous_state_type = state.state_type
         except Exception:
             logger.error("Unexpected error in polling loop", exc_info=True)

--- a/game/state.py
+++ b/game/state.py
@@ -3,6 +3,11 @@ from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
+# Denylist of state_types that do NOT require player input.
+# Start minimal — unknown states trigger votes and surface via options.py warnings during testing.
+# Add entries here as non-input states are discovered through live testing.
+IDLE_STATES: frozenset[str] = frozenset({"menu", "game_over", "unknown", "rewards"})
+
 
 @dataclass
 class GameState:
@@ -33,6 +38,10 @@ class GameState:
             player_hp=player.get("hp"),
             player_max_hp=player.get("max_hp"),
         )
+
+    def requires_player_input(self) -> bool:
+        """Return True when the game state needs a player decision."""
+        return self.state_type not in IDLE_STATES
 
     def summary(self) -> str:
         """One-line description of current state for terminal logging."""

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import sys
 from bot.client import TwitchBot
 from config.loader import load_config
 from game.api_client import STS2Client
+from game.events import GameEvent
 from game.polling import poll_game_state
 
 logging.basicConfig(
@@ -35,9 +36,12 @@ async def main() -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     interval = config["game"]["poll_interval_seconds"]
+    event_queue: asyncio.Queue[GameEvent] = asyncio.Queue()
 
-    async with TwitchBot(config) as bot:
-        poll_task = asyncio.create_task(poll_game_state(game_client, interval))
+    async with TwitchBot(config, event_queue, game_client) as bot:
+        poll_task = asyncio.create_task(
+            poll_game_state(game_client, interval, event_queue)
+        )
         try:
             await bot.start()
         finally:


### PR DESCRIPTION
## Summary

- Typed `GameEvent` queue connecting polling loop to bot (`VoteNeededEvent`, `GameStartedEvent`, `GameEndedEvent`)
- `VoteManager`: 10s vote window, option validation, `Counter` tally, winner announced in chat
- `game/options.py`: `KNOWN_STATES` registry with warning fallback for unknown state_types
- `game/events.py`: extensible event union — new event types (e.g. boss encounter) added here in 1.0
- `IDLE_STATES`: `menu`, `game_over`, `unknown`, `rewards` (discovered during live testing)
- `KNOWN_STATES`: `monster` (1–5, end), `card_reward`, `event`, `hand_select` (1–5), `map` (left/right)
- `game_client` passed to `TwitchBot` as seam for Issue #5 action execution — no refactoring needed
- `CommandNotFound` noise from `!1`, `!end`, etc. silenced in `event_command_error`

## Test plan

- [x] Bot connects to Twitch and posts "Bot is online!"
- [x] Game start transition (menu → run) posts "A new run has started!" in chat
- [x] Vote window opens with correct options per state_type (verified: monster, map, event, card_reward, hand_select)
- [x] `!`-prefixed votes collected and validated against options list
- [x] Winner announced in chat: `"Vote closed! Winner: !1 (1 vote(s))."`
- [x] No-votes case: `"Vote closed — no votes received."`
- [x] IDLE states (menu, unknown, rewards) do not trigger vote windows
- [x] Unknown state_types surface as WARNING logs with instructions to add to KNOWN_STATES
- [x] No game action sent to API

## Related

- Closes #4
- Created #16 (vote fallback for no-votes/ties — needed before #5)
- Created #17 (full state catalog and post-run state handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)