### PR TITLE
Implement Issue #5: first game action execution

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,17 +4,18 @@
 `PoC`
 
 ## Recently Completed
-- #4 — PoC: Basic Vote Window: typed event queue, 10s vote window, KNOWN_STATES registry, game start/end announcements, live-tested state_types
+- #5 — PoC: First Game Action Execution: vote winner sent to STS2MCP API, random fallback on no votes/tie, retry on API failure, live-tested end-to-end
+- #16 — Vote window random fallback: absorbed into #5
+- #4 — PoC: Basic Vote Window: typed event queue, 10s vote window, KNOWN_STATES registry, game start/end announcements
 - #3 — PoC: Game State Polling Loop: 1s poll of STS2MCP, state_type transitions logged, clean Ctrl+C shutdown
-- #2 — PoC Bot Implementation: bot connects to Twitch, posts "Bot is online!", pings STS2MCP API, responds to `!test`
 
 ## Active Issue
-None — #4 complete, ready for #5
+None — #5 complete, ready for #19 or #6
 
 ## Up Next
-1. #5 — PoC: First Game Action Execution
-2. #16 — Vote window: random fallback when no votes / tied (needed before #5)
-3. #6 — STS2-MenuControl Integration
+1. #19 — Combat: resolve target entity_id for play_card actions (blocker for combat)
+2. #6 — STS2-MenuControl Integration
+3. #17 — Catalog full game state_type map and handle post-run states
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)
@@ -25,5 +26,5 @@ None — #4 complete, ready for #5
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
 - STS2 API returns lowercase state_types (e.g. `menu`, `monster`, `card_reward`)
-- `game/events.py` typed event union is the extension point for new game notifications
-- `game/options.py` KNOWN_STATES is the living registry for state_type → vote options
+- `game/actions.py` is the translation layer: (state_type, vote_option) → API request body
+- All state_type→API mappings need live verification; map options especially unverified

--- a/bot/client.py
+++ b/bot/client.py
@@ -6,6 +6,7 @@ from twitchio import eventsub
 from twitchio.ext import commands
 
 from bot.vote_manager import VoteManager
+from game.actions import build_api_body
 from game.api_client import STS2Client
 from game.events import GameEndedEvent, GameEvent, GameStartedEvent, VoteNeededEvent
 from game.options import options_for_state
@@ -51,7 +52,7 @@ class TwitchBot(commands.Bot):
         self._owner_refresh_token = config["twitch"]["owner_refresh_token"]
 
         self._event_queue = event_queue
-        self._game_client = game_client  # unused in #4; seam for #5 action execution
+        self._game_client = game_client
         self.vote_manager = VoteManager(config["vote"]["duration_seconds"])
 
         super().__init__(
@@ -128,9 +129,31 @@ class TwitchBot(commands.Bot):
                         options=options,
                         state_summary=event.state.summary(),
                     )
-                    logger.info("Vote result: %s", winner)
-                    # In #5: replace the line above with:
-                    # await self._game_client.post_action(winner)
+
+                    try:
+                        body = build_api_body(event.state, winner)
+                    except ValueError:
+                        logger.error(
+                            "No API mapping for state=%s winner=%s — skipping action",
+                            event.state.state_type,
+                            winner,
+                        )
+                        self._event_queue.task_done()
+                        continue
+
+                    result = await self._game_client.post_action(body)
+                    if result is None:
+                        logger.warning("Action POST failed, retrying once...")
+                        result = await self._game_client.post_action(body)
+                        if result is None:
+                            logger.error(
+                                "Action POST failed twice for body=%s — system may be stuck",
+                                body,
+                            )
+                        else:
+                            logger.info("Action executed (retry): %s → %s", winner, result)
+                    else:
+                        logger.info("Action executed: %s → %s", winner, result)
 
                 self._event_queue.task_done()
 

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import random
 from collections import Counter
 
 import twitchio
@@ -43,10 +44,11 @@ class VoteManager:
         bot_id: str,
         options: list[str],
         state_summary: str,
-    ) -> str | None:
+    ) -> str:
         """Open a vote window, collect votes, tally, announce winner.
 
-        Returns the winning choice string, or None if no votes were cast.
+        Always returns a winning choice string. If no votes were cast or votes
+        are tied, a winner is chosen randomly and chat is notified.
         """
         self._votes = {}
         self._options = frozenset(options)
@@ -65,11 +67,17 @@ class VoteManager:
         self._open = False
         logger.info("Vote window closed. %d vote(s) cast.", len(self._votes))
 
-        winner = self._tally()
+        winner, was_random, was_tie = self._tally(options)
 
-        if winner is None:
+        if was_random:
             await broadcaster.send_message(
-                message="Vote closed — no votes received.",
+                message=f"Vote closed — no votes, random pick: !{winner}",
+                sender=bot_id,
+                token_for=bot_id,
+            )
+        elif was_tie:
+            await broadcaster.send_message(
+                message=f"Vote closed! Tie broken randomly: !{winner}",
                 sender=bot_id,
                 token_for=bot_id,
             )
@@ -83,8 +91,24 @@ class VoteManager:
 
         return winner
 
-    def _tally(self) -> str | None:
+    def _tally(self, options: list[str]) -> tuple[str, bool, bool]:
+        """Return (winner, was_random, was_tie).
+
+        was_random: True when no votes were cast (winner chosen from full options list).
+        was_tie: True when multiple options share the top vote count (winner chosen randomly among them).
+        """
         if not self._votes:
-            return None
+            winner = random.choice(options)
+            logger.info("No votes cast — random fallback: %s", winner)
+            return winner, True, False
+
         counts = Counter(self._votes.values())
-        return counts.most_common(1)[0][0]
+        max_count = counts.most_common(1)[0][1]
+        tied = [choice for choice, count in counts.items() if count == max_count]
+
+        if len(tied) > 1:
+            winner = random.choice(tied)
+            logger.info("Tie between %s — random winner: %s", tied, winner)
+            return winner, False, True
+
+        return tied[0], False, False

--- a/game/actions.py
+++ b/game/actions.py
@@ -1,0 +1,57 @@
+import logging
+
+from game.state import GameState
+
+logger = logging.getLogger(__name__)
+
+
+def build_api_body(state: GameState, winner: str) -> dict:
+    """Translate a vote winner string into a STS2MCP action request body.
+
+    Vote options are 1-indexed strings (e.g. "1", "2"); the API uses 0-indexed
+    integers. Raises ValueError for unrecognised (state_type, winner) pairs so
+    bad mappings surface loudly during PoC live testing.
+    """
+    st = state.state_type
+
+    if st == "monster":
+        if winner == "end":
+            return {"action": "end_turn"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "play_card", "card_index": idx}
+        except ValueError:
+            pass
+
+    elif st == "card_reward":
+        try:
+            idx = int(winner) - 1
+            return {"action": "select_card_reward", "card_index": idx}
+        except ValueError:
+            pass
+
+    elif st == "map":
+        try:
+            idx = int(winner) - 1
+            return {"action": "choose_map_node", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "event":
+        try:
+            idx = int(winner) - 1
+            return {"action": "choose_event_option", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "hand_select":
+        try:
+            idx = int(winner) - 1
+            return {"action": "combat_select_card", "card_index": idx}
+        except ValueError:
+            pass
+
+    raise ValueError(
+        f"No API mapping for state_type={st!r}, winner={winner!r}. "
+        "Add this combination to game/actions.py."
+    )

--- a/game/api_client.py
+++ b/game/api_client.py
@@ -24,3 +24,20 @@ class STS2Client:
             return None
         except (httpx.ConnectError, httpx.TimeoutException):
             return None
+
+    async def post_action(self, body: dict) -> dict | None:
+        """Submit a player action to STS2MCP. Returns parsed JSON or None on failure."""
+        try:
+            response = await self._http.post(
+                f"{self._base_url}/api/v1/singleplayer", json=body
+            )
+            if response.is_success:
+                return response.json()
+            logger.warning(
+                "STS2MCP action POST returned status %s: %s",
+                response.status_code,
+                response.text,
+            )
+            return None
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return None

--- a/game/options.py
+++ b/game/options.py
@@ -11,7 +11,7 @@ KNOWN_STATES: dict[str, list[str]] = {
     "monster":     ["1", "2", "3", "4", "5", "end"],  # combat encounter
     "hand_select": ["1", "2", "3", "4", "5"],          # select a card from hand (card effect)
     "card_reward": ["1", "2", "3"],
-    "map":         ["left", "right"],
+    "map":         ["1", "2", "3", "4", "5"],  # node index — exact count unverified; trim via live testing
     "event":       ["1", "2", "3"],
 }
 


### PR DESCRIPTION
## Summary

- Adds `game/actions.py` — translation layer from `(state_type, vote_option)` to STS2MCP API request body
- Adds `STS2Client.post_action()` — POSTs winning action to `POST /api/v1/singleplayer`
- `VoteManager` now always returns a winner — random fallback on no votes or tied votes (absorbs #16)
- `bot/client.py` wires the full loop: vote winner → `build_api_body` → `post_action` with one retry on failure
- `game/options.py` map options changed from `left/right` to numeric indices (consistent with other states; exact count to be verified via live testing)

## Absorbs

Closes #16 — vote window random fallback

## Test plan

- [x] Vote collected and sent to STS2MCP API — confirmed live (`!1` in monster state)
- [x] API response logged at INFO level — confirmed live
- [x] Random fallback on no votes — confirmed live (chat message + terminal log)
- [x] Bot does not crash on API error response — confirmed live (structured error returned, loop continued)
- [ ] Retry path on API unreachable — inferred from code, not directly tested

## Notes

- Issue #19 created for combat targeting (`play_card` requires `entity_id` for targeted cards)
- All state_type→API mappings need further live verification as the bot is used in real runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)