### PR TITLE
Implement Issue #19: resolve target entity_id for play_card actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ A "Twitch Plays" bot for Slay the Spire 2. The streamer plays STS2 on PC and str
 
 ## External Mods (must be installed in STS2 before running)
 
-- **STS2MCP**: https://github.com/Gennadiyev/STS2MCP — full game state + actions via REST on `localhost:8080`
+- **STS2MCP**: https://github.com/Gennadiyev/STS2MCP — full game state + actions via REST on `localhost:15526`
 - **STS2-MenuControl**: https://github.com/L4ntern0/STS2-MenuControl — menu interactions via REST on `localhost:8081`
 
 ## Session Rules
@@ -36,6 +36,12 @@ A "Twitch Plays" bot for Slay the Spire 2. The streamer plays STS2 on PC and str
 - **No commits without explicit user request.** Never run `git commit` or `git push` unless the user explicitly asks.
 - **End of session:** Run `/end-session` when the active issue's acceptance criteria are met.
 - **Branch naming:** `issue-{number}/{short-description}` (e.g. `issue-2/poc-bot`). One branch per issue. Branch off `main`.
+
+## Running the Bot
+
+- Use `python3 main.py` (not `python` — that command is not found on this machine)
+- Claude runs and monitors the bot during testing sessions; the user focuses on the game
+- TwitchIO logs a non-fatal OSError about port 4343 on startup — this is expected and can be ignored
 
 ## Coding Conventions
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,18 +4,19 @@
 `PoC`
 
 ## Recently Completed
+- #19 — Combat: target entity_id for play_card: enemies captured in GameState, auto-target first enemy, fresh state re-fetched at action time, live-tested (Strike targeting Nibbit)
 - #5 — PoC: First Game Action Execution: vote winner sent to STS2MCP API, random fallback on no votes/tie, retry on API failure, live-tested end-to-end
-- #16 — Vote window random fallback: absorbed into #5
 - #4 — PoC: Basic Vote Window: typed event queue, 10s vote window, KNOWN_STATES registry, game start/end announcements
 - #3 — PoC: Game State Polling Loop: 1s poll of STS2MCP, state_type transitions logged, clean Ctrl+C shutdown
 
 ## Active Issue
-None — #5 complete, ready for #19 or #6
+None — #19 complete
 
 ## Up Next
-1. #19 — Combat: resolve target entity_id for play_card actions (blocker for combat)
-2. #6 — STS2-MenuControl Integration
-3. #17 — Catalog full game state_type map and handle post-run states
+1. #21 — Stale vote queue: discard votes when state has moved on (blocker for clean UX)
+2. #11 — Detect within-state game changes (re-queue vote after each card play)
+3. #6 — STS2-MenuControl Integration
+4. #17 — Catalog full game state_type map and handle post-run states
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)
@@ -25,6 +26,6 @@ None — #5 complete, ready for #19 or #6
 - No automated tests for PoC
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
-- STS2 API returns lowercase state_types (e.g. `menu`, `monster`, `card_reward`)
+- STS2MCP API on `localhost:15526`; enemy `entity_id` lives at `battle.enemies[i].entity_id`
 - `game/actions.py` is the translation layer: (state_type, vote_option) → API request body
-- All state_type→API mappings need live verification; map options especially unverified
+- Re-fetch fresh state after vote closes to avoid stale enemy data at action time

--- a/bot/client.py
+++ b/bot/client.py
@@ -10,6 +10,7 @@ from game.actions import build_api_body
 from game.api_client import STS2Client
 from game.events import GameEndedEvent, GameEvent, GameStartedEvent, VoteNeededEvent
 from game.options import options_for_state
+from game.state import GameState
 
 logger = logging.getLogger(__name__)
 
@@ -130,8 +131,19 @@ class TwitchBot(commands.Bot):
                         state_summary=event.state.summary(),
                     )
 
+                    # Re-fetch state so action uses fresh data (e.g. enemies list
+                    # may be empty on the first monster poll that queued the vote).
+                    fresh_data = await self._game_client.get_state()
+                    if fresh_data:
+                        try:
+                            action_state = GameState.from_api_response(fresh_data)
+                        except ValueError:
+                            action_state = event.state
+                    else:
+                        action_state = event.state
+
                     try:
-                        body = build_api_body(event.state, winner)
+                        body = build_api_body(action_state, winner)
                     except ValueError:
                         logger.error(
                             "No API mapping for state=%s winner=%s — skipping action",

--- a/game/actions.py
+++ b/game/actions.py
@@ -14,12 +14,15 @@ def build_api_body(state: GameState, winner: str) -> dict:
     """
     st = state.state_type
 
-    if st == "monster":
+    if st in {"monster", "elite", "boss"}:
         if winner == "end":
             return {"action": "end_turn"}
         try:
             idx = int(winner) - 1
-            return {"action": "play_card", "card_index": idx}
+            body: dict = {"action": "play_card", "card_index": idx}
+            if state.enemies:
+                body["target"] = state.enemies[0]["entity_id"]
+            return body
         except ValueError:
             pass
 
@@ -41,6 +44,30 @@ def build_api_body(state: GameState, winner: str) -> dict:
         try:
             idx = int(winner) - 1
             return {"action": "choose_event_option", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "shop":
+        if winner == "end":
+            return {"action": "proceed"}
+
+    elif st == "rest_site":
+        try:
+            idx = int(winner) - 1
+            return {"action": "choose_rest_option", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "rewards":
+        if winner == "end":
+            return {"action": "proceed"}
+
+    elif st == "treasure":
+        if winner == "end":
+            return {"action": "proceed"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "claim_treasure_relic", "index": idx}
         except ValueError:
             pass
 

--- a/game/options.py
+++ b/game/options.py
@@ -9,10 +9,16 @@ logger = logging.getLogger(__name__)
 # to add them here. In 1.0, values will be replaced with real API-derived options.
 KNOWN_STATES: dict[str, list[str]] = {
     "monster":     ["1", "2", "3", "4", "5", "end"],  # combat encounter
+    "elite":       ["1", "2", "3", "4", "5", "end"],  # elite combat
+    "boss":        ["1", "2", "3", "4", "5", "end"],  # boss combat
     "hand_select": ["1", "2", "3", "4", "5"],          # select a card from hand (card effect)
     "card_reward": ["1", "2", "3"],
     "map":         ["1", "2", "3", "4", "5"],  # node index — exact count unverified; trim via live testing
     "event":       ["1", "2", "3"],
+    "shop":        ["end"],                            # "end" → proceed (leave shop)
+    "rest_site":   ["1", "2", "3"],                    # rest site options
+    "rewards":     ["end"],                            # "end" → proceed (leave rewards screen)
+    "treasure":    ["1", "end"],                       # "1" → claim relic, "end" → proceed
 }
 
 

--- a/game/state.py
+++ b/game/state.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +16,7 @@ class GameState:
     floor: int | None
     player_hp: int | None
     player_max_hp: int | None
+    enemies: list[dict] = field(default_factory=list)  # Combat only; empty outside combat
 
     @classmethod
     def from_api_response(cls, data: dict) -> "GameState":
@@ -30,6 +31,7 @@ class GameState:
 
         run = data.get("run") or {}
         player = data.get("player") or {}
+        battle = data.get("battle") or {}
 
         return cls(
             state_type=data["state_type"],
@@ -37,6 +39,7 @@ class GameState:
             floor=run.get("floor"),
             player_hp=player.get("hp"),
             player_max_hp=player.get("max_hp"),
+            enemies=battle.get("enemies") or [],
         )
 
     def requires_player_input(self) -> bool:


### PR DESCRIPTION
## Summary

- `GameState` now captures `battle.enemies` from the API response, exposing `entity_id` for targeting
- `build_api_body()` includes `"target": enemies[0].entity_id` for `monster`/`elite`/`boss` states (auto-targets first enemy for PoC)
- `bot/client.py` re-fetches fresh game state after the vote closes, so enemies list is never stale at action time
- Extended `KNOWN_STATES` and action mappings for `shop`, `rest_site`, `rewards`, and `treasure` (unblocks navigation past these screens)
- `CLAUDE.md` updated: STS2MCP port corrected to `15526`, bot-running conventions added

## Test plan

- [x] `Strike` played in combat — API responded `"Playing 'Strike' targeting Nibbit"` with no targeting error
- [x] Non-targeted card (`Defend`) still plays without error (target field silently ignored by API)
- [x] `shop`, `rest_site`, `rewards`, `treasure` states no longer log `No API mapping` errors

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)