### PR TITLE
fix(#21): discard stale votes when game state has moved on

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,19 +4,17 @@
 `PoC`
 
 ## Recently Completed
+- #21 — Stale vote queue: pre-window + post-window state checks in `_event_runner`; stale votes discarded with WARNING log; live-tested through event→map→monster transition
 - #19 — Combat: target entity_id for play_card: enemies captured in GameState, auto-target first enemy, fresh state re-fetched at action time, live-tested (Strike targeting Nibbit)
 - #5 — PoC: First Game Action Execution: vote winner sent to STS2MCP API, random fallback on no votes/tie, retry on API failure, live-tested end-to-end
-- #4 — PoC: Basic Vote Window: typed event queue, 10s vote window, KNOWN_STATES registry, game start/end announcements
-- #3 — PoC: Game State Polling Loop: 1s poll of STS2MCP, state_type transitions logged, clean Ctrl+C shutdown
 
 ## Active Issue
-None — #19 complete
+None — #21 complete
 
 ## Up Next
-1. #21 — Stale vote queue: discard votes when state has moved on (blocker for clean UX)
-2. #11 — Detect within-state game changes (re-queue vote after each card play)
-3. #6 — STS2-MenuControl Integration
-4. #17 — Catalog full game state_type map and handle post-run states
+1. #11 — Detect within-state game changes (re-queue vote after each card play)
+2. #6 — STS2-MenuControl Integration
+3. #17 — Catalog full game state_type map and handle post-run states
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)

--- a/bot/client.py
+++ b/bot/client.py
@@ -123,6 +123,23 @@ class TwitchBot(commands.Bot):
                     )
 
                 elif isinstance(event, VoteNeededEvent):
+                    # Check 1: discard if the game has already moved on since this
+                    # event was queued (common during rapid floor-0 transitions).
+                    pre_vote_data = await self._game_client.get_state()
+                    if pre_vote_data:
+                        try:
+                            pre_vote_state = GameState.from_api_response(pre_vote_data)
+                            if pre_vote_state.state_type != event.state.state_type:
+                                logger.warning(
+                                    "Discarding stale vote: queued for '%s' but game is now '%s'",
+                                    event.state.state_type,
+                                    pre_vote_state.state_type,
+                                )
+                                self._event_queue.task_done()
+                                continue
+                        except ValueError:
+                            pass  # Can't parse fresh state — proceed with the vote anyway
+
                     options = options_for_state(event.state)
                     winner = await self.vote_manager.run_window(
                         broadcaster=broadcaster,
@@ -141,6 +158,17 @@ class TwitchBot(commands.Bot):
                             action_state = event.state
                     else:
                         action_state = event.state
+
+                    # Check 2: discard if the game moved on while the vote window
+                    # was open (e.g. state changed during the 10-second window).
+                    if action_state.state_type != event.state.state_type:
+                        logger.warning(
+                            "Discarding stale vote result: queued for '%s' but game is now '%s'",
+                            event.state.state_type,
+                            action_state.state_type,
+                        )
+                        self._event_queue.task_done()
+                        continue
 
                     try:
                         body = build_api_body(action_state, winner)


### PR DESCRIPTION
## Summary

- Adds a **pre-window check** in `_event_runner`: fetches fresh state before opening the vote window and discards the event if `state_type` has already changed
- Adds a **post-window check**: after the vote window closes, verifies the re-fetched state still matches the queued event's `state_type` before executing the action
- Both checks emit a `WARNING` log when discarding: `Discarding stale vote: queued for 'X' but game is now 'Y'`

## Test plan

- [x] Started a new run; game transitioned event→map→monster rapidly at floor 0
- [x] `event` vote window opened, game moved to `map` mid-window → post-window check discarded the `event` vote
- [x] `map` vote window opened, game moved to `monster` mid-window → post-window check discarded the `map` vote  
- [x] `monster` vote window opened cleanly, `end` action executed successfully (`{'status': 'ok', 'message': 'Ending turn'}`)
- [x] No stale API errors, no double card plays

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)