### PR TITLE
feat(#11): catalog state_type map and detect within-state game changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ A "Twitch Plays" bot for Slay the Spire 2. The streamer plays STS2 on PC and str
 - Use `python3 main.py` (not `python` — that command is not found on this machine)
 - Claude runs and monitors the bot during testing sessions; the user focuses on the game
 - TwitchIO logs a non-fatal OSError about port 4343 on startup — this is expected and can be ignored
+- **End of session:** Stop the bot process (via `TaskStop`) before closing out with `/end-session`
 
 ## Coding Conventions
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,17 +4,17 @@
 `PoC`
 
 ## Recently Completed
+- #11 — State map catalog + within-state detection: full state_type map, `is_play_phase` vote trigger, dynamic playable-card options, within-turn re-queue, stale checks for combat; live-tested full run
 - #21 — Stale vote queue: pre-window + post-window state checks in `_event_runner`; stale votes discarded with WARNING log; live-tested through event→map→monster transition
 - #19 — Combat: target entity_id for play_card: enemies captured in GameState, auto-target first enemy, fresh state re-fetched at action time, live-tested (Strike targeting Nibbit)
-- #5 — PoC: First Game Action Execution: vote winner sent to STS2MCP API, random fallback on no votes/tie, retry on API failure, live-tested end-to-end
 
 ## Active Issue
-None — #21 complete
+None — #11 complete
 
 ## Up Next
-1. #11 — Detect within-state game changes (re-queue vote after each card play)
-2. #6 — STS2-MenuControl Integration
-3. #17 — Catalog full game state_type map and handle post-run states
+1. #6 — STS2-MenuControl Integration (pre-run menu/character selection only; all in-run states handled by STS2MCP)
+2. #7 — Database Logging
+3. #9 — Production Hardening
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)
@@ -26,4 +26,4 @@ None — #21 complete
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
 - STS2MCP API on `localhost:15526`; enemy `entity_id` lives at `battle.enemies[i].entity_id`
 - `game/actions.py` is the translation layer: (state_type, vote_option) → API request body
-- Re-fetch fresh state after vote closes to avoid stale enemy data at action time
+- Vote options use actual 1-indexed hand positions (matching in-game card numbers); `can_play` field determines what's offered

--- a/bot/client.py
+++ b/bot/client.py
@@ -137,6 +137,17 @@ class TwitchBot(commands.Bot):
                                 )
                                 self._event_queue.task_done()
                                 continue
+                            # For combat states, also discard if it's now the enemy's turn
+                            if (
+                                pre_vote_state.is_combat_state()
+                                and pre_vote_state.is_play_phase is False
+                            ):
+                                logger.warning(
+                                    "Discarding stale vote: combat state '%s' but is_play_phase=False (enemy turn)",
+                                    event.state.state_type,
+                                )
+                                self._event_queue.task_done()
+                                continue
                         except ValueError:
                             pass  # Can't parse fresh state — proceed with the vote anyway
 
@@ -160,11 +171,21 @@ class TwitchBot(commands.Bot):
                         action_state = event.state
 
                     # Check 2: discard if the game moved on while the vote window
-                    # was open (e.g. state changed during the 10-second window).
+                    # was open (e.g. state changed during the vote duration).
                     if action_state.state_type != event.state.state_type:
                         logger.warning(
                             "Discarding stale vote result: queued for '%s' but game is now '%s'",
                             event.state.state_type,
+                            action_state.state_type,
+                        )
+                        self._event_queue.task_done()
+                        continue
+                    if (
+                        action_state.is_combat_state()
+                        and action_state.is_play_phase is False
+                    ):
+                        logger.warning(
+                            "Discarding stale vote result: combat state '%s' but is_play_phase=False (enemy turn)",
                             action_state.state_type,
                         )
                         self._event_queue.task_done()

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -94,11 +94,18 @@ class VoteManager:
     def _tally(self, options: list[str]) -> tuple[str, bool, bool]:
         """Return (winner, was_random, was_tie).
 
-        was_random: True when no votes were cast (winner chosen from full options list).
-        was_tie: True when multiple options share the top vote count (winner chosen randomly among them).
+        was_random: True when no votes were cast (winner chosen from random pool).
+        was_tie: True when multiple options share the top vote count (winner chosen randomly among tied).
+
+        Random fallback and tie-breaking only pick from numeric options (e.g. "1", "2") so
+        terminal actions like "end", "skip", "cancel" are never chosen without an explicit vote.
+        Falls back to the full options list only if there are no numeric options at all.
         """
+        numeric_options = [o for o in options if o.isdigit()]
+        random_pool = numeric_options if numeric_options else options
+
         if not self._votes:
-            winner = random.choice(options)
+            winner = random.choice(random_pool)
             logger.info("No votes cast — random fallback: %s", winner)
             return winner, True, False
 
@@ -107,7 +114,9 @@ class VoteManager:
         tied = [choice for choice, count in counts.items() if count == max_count]
 
         if len(tied) > 1:
-            winner = random.choice(tied)
+            # Break ties using only numeric options that were among the tied choices
+            numeric_tied = [c for c in tied if c.isdigit()]
+            winner = random.choice(numeric_tied if numeric_tied else tied)
             logger.info("Tie between %s — random winner: %s", tied, winner)
             return winner, False, True
 

--- a/game/actions.py
+++ b/game/actions.py
@@ -18,15 +18,36 @@ def build_api_body(state: GameState, winner: str) -> dict:
         if winner == "end":
             return {"action": "end_turn"}
         try:
-            idx = int(winner) - 1
-            body: dict = {"action": "play_card", "card_index": idx}
+            # Vote number matches the 1-indexed hand position shown in-game
+            card_index = int(winner) - 1
+            body: dict = {"action": "play_card", "card_index": card_index}
             if state.enemies:
                 body["target"] = state.enemies[0]["entity_id"]
             return body
         except ValueError:
             pass
 
+    elif st == "hand_select":
+        if winner == "confirm":
+            return {"action": "combat_confirm_selection"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "combat_select_card", "card_index": idx}
+        except ValueError:
+            pass
+
+    elif st == "rewards":
+        if winner == "end":
+            return {"action": "proceed"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "claim_reward", "index": idx}
+        except ValueError:
+            pass
+
     elif st == "card_reward":
+        if winner == "skip":
+            return {"action": "skip_card_reward"}
         try:
             idx = int(winner) - 1
             return {"action": "select_card_reward", "card_index": idx}
@@ -47,10 +68,6 @@ def build_api_body(state: GameState, winner: str) -> dict:
         except ValueError:
             pass
 
-    elif st == "shop":
-        if winner == "end":
-            return {"action": "proceed"}
-
     elif st == "rest_site":
         try:
             idx = int(winner) - 1
@@ -58,9 +75,23 @@ def build_api_body(state: GameState, winner: str) -> dict:
         except ValueError:
             pass
 
-    elif st == "rewards":
+    elif st == "shop":
         if winner == "end":
             return {"action": "proceed"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "shop_purchase", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "fake_merchant":
+        if winner == "end":
+            return {"action": "proceed"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "shop_purchase", "index": idx}
+        except ValueError:
+            pass
 
     elif st == "treasure":
         if winner == "end":
@@ -71,12 +102,51 @@ def build_api_body(state: GameState, winner: str) -> dict:
         except ValueError:
             pass
 
-    elif st == "hand_select":
+    elif st == "card_select":
+        if winner == "confirm":
+            return {"action": "confirm_selection"}
+        if winner == "cancel":
+            return {"action": "cancel_selection"}
         try:
             idx = int(winner) - 1
-            return {"action": "combat_select_card", "card_index": idx}
+            return {"action": "select_card", "index": idx}
         except ValueError:
             pass
+
+    elif st == "bundle_select":
+        if winner == "cancel":
+            return {"action": "cancel_bundle_selection"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "select_bundle", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "relic_select":
+        if winner == "skip":
+            return {"action": "skip_relic_selection"}
+        try:
+            idx = int(winner) - 1
+            return {"action": "select_relic", "index": idx}
+        except ValueError:
+            pass
+
+    elif st == "crystal_sphere":
+        try:
+            idx = int(winner) - 1
+            cells = state.crystal_sphere_cells
+            if not cells:
+                raise ValueError("crystal_sphere_cells is empty — cannot resolve coordinates")
+            if idx >= len(cells):
+                raise ValueError(
+                    f"Vote index {idx} out of range; only {len(cells)} clickable cells available"
+                )
+            cell = cells[idx]
+            return {"action": "crystal_sphere_click_cell", "x": cell["x"], "y": cell["y"]}
+        except (ValueError, KeyError) as exc:
+            raise ValueError(
+                f"crystal_sphere action failed for winner={winner!r}: {exc}"
+            ) from exc
 
     raise ValueError(
         f"No API mapping for state_type={st!r}, winner={winner!r}. "

--- a/game/options.py
+++ b/game/options.py
@@ -5,30 +5,50 @@ from game.state import GameState
 logger = logging.getLogger(__name__)
 
 # Living registry of state_type → vote options.
-# During live testing, unknown state_types surface as WARNING logs with instructions
-# to add them here. In 1.0, values will be replaced with real API-derived options.
+# All state_types from the STS2MCP API are enumerated here.
+# Numeric options ("1", "2", ...) are 1-indexed and map to 0-indexed API calls in actions.py.
 KNOWN_STATES: dict[str, list[str]] = {
-    "monster":     ["1", "2", "3", "4", "5", "end"],  # combat encounter
-    "elite":       ["1", "2", "3", "4", "5", "end"],  # elite combat
-    "boss":        ["1", "2", "3", "4", "5", "end"],  # boss combat
-    "hand_select": ["1", "2", "3", "4", "5"],          # select a card from hand (card effect)
-    "card_reward": ["1", "2", "3"],
-    "map":         ["1", "2", "3", "4", "5"],  # node index — exact count unverified; trim via live testing
-    "event":       ["1", "2", "3"],
-    "shop":        ["end"],                            # "end" → proceed (leave shop)
-    "rest_site":   ["1", "2", "3"],                    # rest site options
-    "rewards":     ["end"],                            # "end" → proceed (leave rewards screen)
-    "treasure":    ["1", "end"],                       # "1" → claim relic, "end" → proceed
+    # Combat encounters
+    "monster":       ["1", "2", "3", "4", "5", "end"],
+    "elite":         ["1", "2", "3", "4", "5", "end"],
+    "boss":          ["1", "2", "3", "4", "5", "end"],
+    # In-combat card selection (exhaust/discard/upgrade prompts)
+    "hand_select":   ["1", "2", "3", "4", "5", "confirm"],
+    # Post-combat rewards
+    "rewards":       ["1", "2", "3", "4", "5", "end"],   # numeric=claim, end=proceed
+    "card_reward":   ["1", "2", "3", "skip"],
+    # Map navigation
+    "map":           ["1", "2", "3", "4", "5"],
+    # Room types
+    "event":         ["1", "2", "3"],
+    "rest_site":     ["1", "2", "3"],
+    "shop":          ["1", "2", "3", "4", "5", "end"],   # numeric=purchase, end=proceed
+    "fake_merchant": ["1", "2", "3", "end"],
+    "treasure":      ["1", "end"],                        # 1=claim relic, end=proceed
+    # Card/relic selection overlays
+    "card_select":   ["1", "2", "3", "4", "5", "confirm", "cancel"],
+    "bundle_select": ["1", "2", "3", "cancel"],
+    "relic_select":  ["1", "2", "3", "skip"],
+    # Crystal Sphere minigame — Nth clickable cell; exact cells resolved at action time
+    "crystal_sphere": ["1", "2", "3", "4", "5"],
 }
 
 
 def options_for_state(state: GameState) -> list[str]:
     """Return the list of valid vote choices for the given game state.
 
+    For combat states (monster/elite/boss), options are derived from the actual
+    hand size so voters only see choices that correspond to real cards.
+
     If the state_type is unrecognised, logs a warning and returns a generic
     fallback so voting is never completely blocked. Add new state_types to
     KNOWN_STATES in this module as they are discovered through live testing.
     """
+    if state.is_combat_state():
+        # Use actual hand positions (1-indexed) so chat options match the in-game card numbers
+        numeric = [str(idx + 1) for idx in state.playable_card_indices]
+        return numeric + ["end"]
+
     options = KNOWN_STATES.get(state.state_type)
     if options is None:
         logger.warning(

--- a/game/polling.py
+++ b/game/polling.py
@@ -8,13 +8,47 @@ from game.state import GameState
 logger = logging.getLogger(__name__)
 
 
+def _log_within_state_changes(prev: GameState, curr: GameState) -> None:
+    """Log meaningful field-level changes when state_type hasn't changed."""
+    if curr.player_hp != prev.player_hp and curr.player_hp is not None:
+        logger.info(
+            "Player HP: %s → %s/%s",
+            prev.player_hp,
+            curr.player_hp,
+            curr.player_max_hp,
+        )
+    if curr.player_block != prev.player_block and curr.player_block is not None:
+        logger.info("Player block: %s → %s", prev.player_block, curr.player_block)
+    if curr.player_energy != prev.player_energy and curr.player_energy is not None:
+        logger.info("Player energy: %s → %s", prev.player_energy, curr.player_energy)
+
+    for i, enemy in enumerate(curr.enemies):
+        if i >= len(prev.enemies):
+            break
+        prev_enemy = prev.enemies[i]
+        if enemy.get("hp") != prev_enemy.get("hp"):
+            logger.info(
+                "%s HP: %s → %s",
+                enemy.get("name", f"Enemy {i}"),
+                prev_enemy.get("hp"),
+                enemy.get("hp"),
+            )
+        if enemy.get("block") != prev_enemy.get("block"):
+            logger.info(
+                "%s block: %s → %s",
+                enemy.get("name", f"Enemy {i}"),
+                prev_enemy.get("block"),
+                enemy.get("block"),
+            )
+
+
 async def poll_game_state(
     client: STS2Client,
     interval: float,
     event_queue: asyncio.Queue[GameEvent],
 ) -> None:
     """Poll STS2MCP every `interval` seconds and emit typed GameEvents on state transitions."""
-    previous_state_type: str | None = None
+    previous_state: GameState | None = None
     api_reachable: bool = True
 
     while True:
@@ -29,16 +63,51 @@ async def poll_game_state(
                     logger.info("STS2MCP API reconnected")
                     api_reachable = True
                 state = GameState.from_api_response(data)
-                if state.state_type != previous_state_type:
+
+                if previous_state is None:
+                    # First successful poll — emit if input needed
+                    logger.info("Initial game state: %s", state.summary())
+                    if state.requires_player_input():
+                        logger.info("Queuing vote for initial state: %s", state.state_type)
+                        event_queue.put_nowait(VoteNeededEvent(state))
+                    previous_state = state
+
+                elif state.state_type != previous_state.state_type:
+                    # State transition
                     logger.info("Game state changed: %s", state.summary())
-                    if previous_state_type == "menu" and state.state_type != "menu":
+                    if previous_state.state_type == "menu" and state.state_type != "menu":
                         event_queue.put_nowait(GameStartedEvent(state))
                     elif state.state_type == "game_over":
                         event_queue.put_nowait(GameEndedEvent(state))
                     elif state.requires_player_input():
                         logger.info("Queuing vote for state: %s", state.state_type)
                         event_queue.put_nowait(VoteNeededEvent(state))
-                    previous_state_type = state.state_type
+                    previous_state = state
+
+                else:
+                    # Same state_type — check for within-state changes
+                    _log_within_state_changes(previous_state, state)
+                    if state.is_combat_state() and state.is_play_phase:
+                        if not previous_state.is_play_phase:
+                            # Edge: enemy turn → player turn
+                            logger.info(
+                                "Player turn started (is_play_phase=True) — queuing vote"
+                            )
+                            event_queue.put_nowait(VoteNeededEvent(state))
+                        elif (
+                            state.hand_size is not None
+                            and previous_state.hand_size is not None
+                            and state.hand_size < previous_state.hand_size
+                        ):
+                            # Card was played mid-turn — re-queue so the next card can be voted on
+                            logger.info(
+                                "Card played mid-turn (hand %d → %d) — re-queuing vote",
+                                previous_state.hand_size,
+                                state.hand_size,
+                            )
+                            event_queue.put_nowait(VoteNeededEvent(state))
+                    previous_state = state
+
         except Exception:
             logger.error("Unexpected error in polling loop", exc_info=True)
         await asyncio.sleep(interval)

--- a/game/state.py
+++ b/game/state.py
@@ -4,9 +4,7 @@ from dataclasses import dataclass, field
 logger = logging.getLogger(__name__)
 
 # Denylist of state_types that do NOT require player input.
-# Start minimal — unknown states trigger votes and surface via options.py warnings during testing.
-# Add entries here as non-input states are discovered through live testing.
-IDLE_STATES: frozenset[str] = frozenset({"menu", "game_over", "unknown", "rewards"})
+IDLE_STATES: frozenset[str] = frozenset({"menu", "game_over", "unknown", "overlay"})
 
 
 @dataclass
@@ -16,7 +14,13 @@ class GameState:
     floor: int | None
     player_hp: int | None
     player_max_hp: int | None
+    player_block: int | None = None       # player.block
+    player_energy: int | None = None      # player.energy (combat only)
+    is_play_phase: bool | None = None          # battle.is_play_phase (combat only)
+    hand_size: int | None = None               # len(player.hand) — used for mid-turn re-queue detection
+    playable_card_indices: list[int] = field(default_factory=list)  # hand indices of can_play=True cards
     enemies: list[dict] = field(default_factory=list)  # Combat only; empty outside combat
+    crystal_sphere_cells: list[dict] = field(default_factory=list)  # crystal_sphere.clickable_cells
 
     @classmethod
     def from_api_response(cls, data: dict) -> "GameState":
@@ -32,6 +36,7 @@ class GameState:
         run = data.get("run") or {}
         player = data.get("player") or {}
         battle = data.get("battle") or {}
+        crystal_sphere = data.get("crystal_sphere") or {}
 
         return cls(
             state_type=data["state_type"],
@@ -39,8 +44,20 @@ class GameState:
             floor=run.get("floor"),
             player_hp=player.get("hp"),
             player_max_hp=player.get("max_hp"),
+            player_block=player.get("block"),
+            player_energy=player.get("energy"),
+            is_play_phase=battle.get("is_play_phase"),
+            hand_size=len(player.get("hand") or []),
+            playable_card_indices=[
+                c["index"] for c in (player.get("hand") or []) if c.get("can_play")
+            ],
             enemies=battle.get("enemies") or [],
+            crystal_sphere_cells=crystal_sphere.get("clickable_cells") or [],
         )
+
+    def is_combat_state(self) -> bool:
+        """Return True when the current state is a combat encounter."""
+        return self.state_type in {"monster", "elite", "boss"}
 
     def requires_player_input(self) -> bool:
         """Return True when the game state needs a player decision."""


### PR DESCRIPTION
## Summary

- Expands `IDLE_STATES`: adds `overlay`, removes `rewards` (now voteable)
- Adds all 16 voteable state_types to `KNOWN_STATES` with correct action mappings in `actions.py` (`fake_merchant`, `card_select`, `bundle_select`, `relic_select`, `crystal_sphere` all new)
- Expands `GameState` with combat fields: `is_play_phase`, `player_block`, `player_energy`, `hand_size`, `playable_card_indices` (cards where `can_play=True`), `crystal_sphere_cells`
- `poll_game_state` now tracks full state snapshots and emits `VoteNeededEvent` on two within-state triggers: `is_play_phase` False→True (player turn starts) and hand shrink while `is_play_phase=True` (card played mid-turn, re-queue for next card)
- Vote options for combat use actual 1-indexed hand positions matching in-game card numbers; only playable cards are offered (`can_play=True`)
- `end`/`skip` excluded from random fallback and tie-breaking — numeric options only
- Extends Check 1 + Check 2 stale guards in `_event_runner` with `is_play_phase` check for combat states

## Test plan

- [x] Vote window opens at start of each player turn (`is_play_phase` flip)
- [x] Second vote window fires after each card played (hand shrink re-queue)
- [x] Dynamic options shrink with hand: `!1 !2 !3 !4 !5 !end` → `!1 !2 !3 !4 !end` → etc.
- [x] At 0 energy, only `!end` offered (no unplayable cards shown)
- [x] Random fallback never picks `end` when cards are available
- [x] Stale vote discarded when `is_play_phase=False` at check time (enemy turn)
- [x] `rewards` → `card_reward` → `rewards` → `map` transition handled cleanly with stale checks
- [x] HP, block, energy, enemy HP logged at INFO on change
- [x] Closes #17 (state catalog merged in; complete map from API docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)