### PR TITLE
feat(#6): STS2-MenuControl integration for character select vote

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -8,7 +8,8 @@ from twitchio.ext import commands
 from bot.vote_manager import VoteManager
 from game.actions import build_api_body
 from game.api_client import STS2Client
-from game.events import GameEndedEvent, GameEvent, GameStartedEvent, VoteNeededEvent
+from game.events import GameEndedEvent, GameEvent, GameStartedEvent, MenuSelectNeededEvent, VoteNeededEvent
+from game.menu_client import MenuClient
 from game.options import options_for_state
 from game.state import GameState
 
@@ -44,6 +45,7 @@ class TwitchBot(commands.Bot):
         config: dict,
         event_queue: asyncio.Queue[GameEvent],
         game_client: STS2Client,
+        menu_client: MenuClient,
     ) -> None:
         self._channel = config["twitch"]["channel"]
         self._owner_id = config["twitch"]["owner_id"]
@@ -54,6 +56,7 @@ class TwitchBot(commands.Bot):
 
         self._event_queue = event_queue
         self._game_client = game_client
+        self._menu_client = menu_client
         self.vote_manager = VoteManager(config["vote"]["duration_seconds"])
 
         super().__init__(
@@ -121,6 +124,9 @@ class TwitchBot(commands.Bot):
                         sender=self.bot_id,
                         token_for=self.bot_id,
                     )
+
+                elif isinstance(event, MenuSelectNeededEvent):
+                    await self._handle_menu_select(broadcaster)
 
                 elif isinstance(event, VoteNeededEvent):
                     # Check 1: discard if the game has already moved on since this
@@ -223,3 +229,108 @@ class TwitchBot(commands.Bot):
                 raise
             except Exception:
                 logger.error("Unexpected error in event runner", exc_info=True)
+
+    async def _handle_menu_select(self, broadcaster: twitchio.PartialUser) -> None:
+        """Handle a MenuSelectNeededEvent: navigate to character select, run vote, embark."""
+        # Retry initial query — MenuControl may still be initializing when STS2MCP first reports menu
+        menu_data = None
+        for _ in range(5):
+            menu_data = await self._menu_client.get_menu_state()
+            if menu_data and menu_data.get("screen") not in (None, "UNKNOWN", "IN_GAME"):
+                break
+            await asyncio.sleep(1.0)
+        if not menu_data:
+            logger.warning("MenuControl API unreachable — skipping character select vote")
+            return
+
+        screen = menu_data.get("screen", "UNKNOWN")
+        available_actions = menu_data.get("available_actions", [])
+
+        if screen == "MAIN_MENU":
+            if "open_character_select" not in available_actions:
+                logger.warning(
+                    "MenuControl: open_character_select unavailable; screen=%s available_actions=%s",
+                    screen,
+                    available_actions,
+                )
+                return
+            result = await self._menu_client.post_menu_action("open_character_select")
+            if result is None:
+                logger.warning("MenuControl: open_character_select POST failed")
+                return
+
+            # Re-query with retries — open_character_select may need a moment to transition
+            for _ in range(3):
+                await asyncio.sleep(0.5)
+                menu_data = await self._menu_client.get_menu_state()
+                if menu_data and menu_data.get("screen") == "CHARACTER_SELECT":
+                    screen = "CHARACTER_SELECT"
+                    break
+            else:
+                logger.warning(
+                    "MenuControl: expected CHARACTER_SELECT after open_character_select, "
+                    "got screen=%s available_actions=%s — skipping",
+                    menu_data.get("screen") if menu_data else None,
+                    menu_data.get("available_actions") if menu_data else None,
+                )
+                return
+
+        if screen != "CHARACTER_SELECT":
+            logger.warning(
+                "MenuControl: unexpected screen=%s — skipping character select vote",
+                screen,
+            )
+            return
+
+        characters = menu_data.get("characters", [])
+        enabled = [c for c in characters if c.get("enabled", False)]
+        if not enabled:
+            logger.warning("MenuControl: no enabled characters found — skipping vote")
+            return
+
+        options = [str(i + 1) for i in range(len(enabled))]
+        ascension: int | None = menu_data.get("ascension")
+
+        def _fmt(char_id: str) -> str:
+            return char_id.replace("_", " ").title()
+
+        char_list = "  ".join(
+            f"!{opt}={_fmt(enabled[int(opt) - 1]['character_id'])}" for opt in options
+        )
+        asc_str = f" | Ascension {ascension}" if ascension else ""
+        await broadcaster.send_message(
+            message=f"Choose your character{asc_str}: {char_list}",
+            sender=self.bot_id,
+            token_for=self.bot_id,
+        )
+
+        winner = await self.vote_manager.run_window(
+            broadcaster=broadcaster,
+            bot_id=self.bot_id,
+            options=options,
+            state_summary=f"character select{asc_str}",
+        )
+
+        winning_pos = int(winner) - 1
+        winning_char_data = enabled[winning_pos]
+        winning_char = _fmt(winning_char_data["character_id"])
+        winning_index = winning_char_data["index"]  # absolute index in full button array
+
+        result = await self._menu_client.post_menu_action(
+            "select_character", option_index=winning_index
+        )
+        if result is None:
+            logger.warning("MenuControl: select_character POST failed")
+            return
+        result = await self._menu_client.post_menu_action("embark")
+        if result is None:
+            logger.warning("MenuControl: embark POST failed")
+            return
+
+        asc_display = f" (Ascension {ascension})" if ascension else ""
+        logger.info("Embarking as %s%s", winning_char, asc_display)
+        await broadcaster.send_message(
+            message=f"Starting run as {winning_char}{asc_display}!",
+            sender=self.bot_id,
+            token_for=self.bot_id,
+        )

--- a/game/events.py
+++ b/game/events.py
@@ -21,4 +21,9 @@ class GameEndedEvent:
     state: GameState
 
 
-GameEvent = VoteNeededEvent | GameStartedEvent | GameEndedEvent
+@dataclass
+class MenuSelectNeededEvent:
+    """Emitted when STS2MCP reports state_type=menu, triggering a character-select vote."""
+
+
+GameEvent = VoteNeededEvent | GameStartedEvent | GameEndedEvent | MenuSelectNeededEvent

--- a/game/menu_client.py
+++ b/game/menu_client.py
@@ -1,0 +1,48 @@
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class MenuClient:
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._http = httpx.AsyncClient(timeout=5.0)
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._http.aclose()
+
+    async def get_menu_state(self) -> dict | None:
+        """Fetch current menu screen state from STS2-MenuControl. Returns parsed JSON or None on failure."""
+        try:
+            response = await self._http.get(f"{self._base_url}/api/v1/menu")
+            if response.is_success:
+                return response.json()
+            logger.warning("MenuControl API returned status %s", response.status_code)
+            return None
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return None
+
+    async def post_menu_action(
+        self, action: str, option_index: int | None = None
+    ) -> dict | None:
+        """Execute a menu action via STS2-MenuControl. Returns parsed JSON or None on failure."""
+        body: dict = {"action": action}
+        if option_index is not None:
+            body["option_index"] = option_index
+        try:
+            response = await self._http.post(
+                f"{self._base_url}/api/v1/menu", json=body
+            )
+            if response.is_success:
+                return response.json()
+            logger.warning(
+                "MenuControl action POST returned status %s: %s",
+                response.status_code,
+                response.text,
+            )
+            return None
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return None

--- a/game/polling.py
+++ b/game/polling.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from game.api_client import STS2Client
-from game.events import GameEndedEvent, GameStartedEvent, GameEvent, VoteNeededEvent
+from game.events import GameEndedEvent, GameStartedEvent, GameEvent, MenuSelectNeededEvent, VoteNeededEvent
 from game.state import GameState
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,10 @@ async def poll_game_state(
                 if previous_state is None:
                     # First successful poll — emit if input needed
                     logger.info("Initial game state: %s", state.summary())
-                    if state.requires_player_input():
+                    if state.state_type == "menu":
+                        logger.info("Game is at main menu — queuing character select vote")
+                        event_queue.put_nowait(MenuSelectNeededEvent())
+                    elif state.requires_player_input():
                         logger.info("Queuing vote for initial state: %s", state.state_type)
                         event_queue.put_nowait(VoteNeededEvent(state))
                     previous_state = state
@@ -79,6 +82,9 @@ async def poll_game_state(
                         event_queue.put_nowait(GameStartedEvent(state))
                     elif state.state_type == "game_over":
                         event_queue.put_nowait(GameEndedEvent(state))
+                    elif state.state_type == "menu":
+                        logger.info("Game is at main menu — queuing character select vote")
+                        event_queue.put_nowait(MenuSelectNeededEvent())
                     elif state.requires_player_input():
                         logger.info("Queuing vote for state: %s", state.state_type)
                         event_queue.put_nowait(VoteNeededEvent(state))

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from bot.client import TwitchBot
 from config.loader import load_config
 from game.api_client import STS2Client
 from game.events import GameEvent
+from game.menu_client import MenuClient
 from game.polling import poll_game_state
 
 logging.basicConfig(
@@ -24,12 +25,19 @@ async def main() -> None:
         sys.exit(1)
 
     game_client = STS2Client(config["api"]["sts2mcp_base_url"])
+    menu_client = MenuClient(config["api"]["sts2_menu_base_url"])
 
     state = await game_client.get_state()
     if state is not None:
         logger.info("STS2MCP API reachable at %s", config["api"]["sts2mcp_base_url"])
     else:
         logger.warning("STS2MCP API not reachable at startup — polling will retry")
+
+    menu_state = await menu_client.get_menu_state()
+    if menu_state is not None:
+        logger.info("MenuControl API reachable at %s", config["api"]["sts2_menu_base_url"])
+    else:
+        logger.warning("MenuControl API not reachable at startup — character select will retry when needed")
 
     # Quieten verbose third-party loggers
     logging.getLogger("twitchio").setLevel(logging.WARNING)
@@ -38,7 +46,7 @@ async def main() -> None:
     interval = config["game"]["poll_interval_seconds"]
     event_queue: asyncio.Queue[GameEvent] = asyncio.Queue()
 
-    async with TwitchBot(config, event_queue, game_client) as bot:
+    async with TwitchBot(config, event_queue, game_client, menu_client) as bot:
         poll_task = asyncio.create_task(
             poll_game_state(game_client, interval, event_queue)
         )
@@ -47,6 +55,7 @@ async def main() -> None:
         finally:
             poll_task.cancel()
             await game_client.close()
+            await menu_client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `game/menu_client.py` — async HTTP wrapper for the STS2-MenuControl REST API (`localhost:8081`), mirroring the `STS2Client` pattern
- Adds `MenuSelectNeededEvent` to the typed event system; polling emits it when `state_type=menu`
- Bot handles the full character-select flow: query screen, navigate to `CHARACTER_SELECT` if needed, announce options to chat, run vote window, `select_character` (using absolute button index to handle disabled entries like `RANDOM_CHARACTER`), `embark`
- `main.py` instantiates and wires `MenuClient`; connectivity logged at startup

## Test plan

- [x] Bot connects to MenuControl API on startup and logs success/failure
- [x] On `state_type=menu`, bot navigates to `CHARACTER_SELECT` and opens vote window
- [x] Chat receives character list with correct options (`!1=Ironclad  !2=Silent  !3=Regent`)
- [x] Winning vote (`!2`) correctly selects Silent (uses absolute `index` field, not enabled-list position)
- [x] Run starts as the winning character; chat notified
- [x] `GameStartedEvent` fires after embark

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)