### PR TITLE
feat(#28): descriptive vote option labels in chat announcements

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,16 +4,20 @@
 `PoC`
 
 ## Recently Completed
-- #21 — Stale vote queue: pre/post-window state checks in `_event_runner`; live-tested
-- #26 — Mid-event option change detection: `event_options` in `GameState`, within-state re-queue, auto-proceed for single proceed option, dynamic event/hand_select/card_select options, auto-confirm for hand_select+card_select, rewards auto-handling (gold/potion auto-claim, card opens for vote, auto-proceed); live-tested full flow
+- #26 — Mid-event option change detection: rewards auto-handling, dynamic options, auto-confirm; live-tested
+- #28 — Descriptive vote labels: `!N=Label` for all in-run states; `game/labels.py`; map left→right preamble; dynamic rest_site/map/shop options; shop shows name+price, filters unaffordable+full-belt potions
+  - Live-tested: combat, event, card_reward, map, rest_site, card_select
+  - Remaining edge cases tracked in #35 (shop names, relic_select, treasure, hand_select)
 
 ## Active Issue
 None
 
 ## Up Next
-1. #7 — Database Logging
-2. #9 — Production Hardening
-3. #28 — Descriptive vote option labels in chat announcements
+1. #35 — Live-test remaining label states (shop, relic_select, treasure, hand_select)
+2. #7 — Database Logging
+3. #9 — Production Hardening
+4. #33 — Rest site Smith: card selection via chat
+5. #34 — Combat: multi-target card voting
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)

--- a/bot/client.py
+++ b/bot/client.py
@@ -10,6 +10,7 @@ from game.actions import build_api_body
 from game.api_client import STS2Client
 from game.events import GameEndedEvent, GameEvent, GameStartedEvent, MenuSelectNeededEvent, VoteNeededEvent
 from game.menu_client import MenuClient
+from game.labels import labels_for_state, preamble_for_state
 from game.options import options_for_state
 from game.state import GameState
 
@@ -169,6 +170,20 @@ class TwitchBot(commands.Bot):
                                 logger.info("Auto-proceeding event (single proceed option) → %s", result)
                                 self._event_queue.task_done()
                                 continue
+                            # Auto-proceed: rest_site after choosing an option (e.g. after Resting)
+                            if (
+                                pre_vote_state.state_type == "rest_site"
+                                and pre_vote_state.rest_site_can_proceed
+                                and not any(
+                                    o.get("is_enabled", True)
+                                    for o in pre_vote_state.rest_site_options
+                                    if not o.get("is_proceed")
+                                )
+                            ):
+                                result = await self._game_client.post_action({"action": "proceed"})
+                                logger.info("Auto-proceeding rest_site → %s", result)
+                                self._event_queue.task_done()
+                                continue
                         except ValueError:
                             pass  # Can't parse fresh state — proceed with the vote anyway
 
@@ -178,6 +193,8 @@ class TwitchBot(commands.Bot):
                         bot_id=self.bot_id,
                         options=options,
                         state_summary=event.state.summary(),
+                        labels=labels_for_state(event.state) or None,
+                        preamble=preamble_for_state(event.state),
                     )
 
                     # Re-fetch state so action uses fresh data (e.g. enemies list

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -44,6 +44,8 @@ class VoteManager:
         bot_id: str,
         options: list[str],
         state_summary: str,
+        labels: dict[str, str] | None = None,
+        preamble: str = "Vote open!",
     ) -> str:
         """Open a vote window, collect votes, tally, announce winner.
 
@@ -55,9 +57,13 @@ class VoteManager:
         self._open = True
         logger.info("Vote window opened for state: %s", state_summary)
 
-        options_str = " | ".join(f"!{o}" for o in options)
+        parts = [
+            f"!{o}={labels[o]}" if (labels and o in labels) else f"!{o}"
+            for o in options
+        ]
+        options_str = "  ".join(parts)
         await broadcaster.send_message(
-            message=f"Vote open! Type: {options_str}  ({self._duration:.0f}s)",
+            message=f"{preamble} {options_str}  ({self._duration:.0f}s)",
             sender=bot_id,
             token_for=bot_id,
         )
@@ -69,22 +75,25 @@ class VoteManager:
 
         winner, was_random, was_tie = self._tally(options)
 
+        winner_label = labels.get(winner) if labels else None
+        winner_str = f"!{winner}={winner_label}" if winner_label else f"!{winner}"
+
         if was_random:
             await broadcaster.send_message(
-                message=f"Vote closed — no votes, random pick: !{winner}",
+                message=f"Vote closed — no votes, random pick: {winner_str}",
                 sender=bot_id,
                 token_for=bot_id,
             )
         elif was_tie:
             await broadcaster.send_message(
-                message=f"Vote closed! Tie broken randomly: !{winner}",
+                message=f"Vote closed! Tie broken randomly: {winner_str}",
                 sender=bot_id,
                 token_for=bot_id,
             )
         else:
             count = sum(1 for v in self._votes.values() if v == winner)
             await broadcaster.send_message(
-                message=f"Vote closed! Winner: !{winner} ({count} vote(s)).",
+                message=f"Vote closed! Winner: {winner_str} ({count} vote(s)).",
                 sender=bot_id,
                 token_for=bot_id,
             )

--- a/game/labels.py
+++ b/game/labels.py
@@ -1,0 +1,124 @@
+import logging
+
+from game.options import _shop_item_available
+from game.state import GameState
+
+logger = logging.getLogger(__name__)
+
+MAP_ROOM_LABELS: dict[str, str] = {
+    "MONSTER": "Fight",
+    "ELITE": "Elite",
+    "BOSS": "Boss",
+    "EVENT": "Event",
+    "REST": "Rest",
+    "RESTSITE": "Rest",       # API returns "RestSite"
+    "SHOP": "Shop",
+    "TREASURE": "Treasure",
+    "TREASUREROOM": "Treasure",  # guard against "TreasureRoom"
+    "UNKNOWN": "?",
+}
+
+
+def labels_for_state(state: GameState) -> dict[str, str]:
+    """Return {option_str: display_label} for chat vote announcements.
+
+    Uses human-readable names from GameState label fields where available.
+    Falls back to 'Option N' for missing numeric labels and capitalised key
+    for missing word-key labels (e.g. 'cancel' → 'Cancel').
+    Returns an empty dict for states with no label data.
+    """
+    if state.is_combat_state():
+        labels: dict[str, str] = {
+            str(idx + 1): state.hand_card_names.get(idx, f"Option {idx + 1}")
+            for idx in state.playable_card_indices
+        }
+        labels["end"] = "End Turn"
+        return labels
+
+    if state.state_type == "event" and state.event_options:
+        return {
+            str(o["index"] + 1): o.get("title") or f"Option {o['index'] + 1}"
+            for o in state.event_options
+            if not o.get("is_locked")
+        }
+
+    if state.state_type == "card_reward":
+        labels = {str(i + 1): name for i, name in enumerate(state.card_reward_names)}
+        if not labels:
+            labels = {}
+        labels["skip"] = "Skip"
+        return labels
+
+    if state.state_type == "rest_site" and state.rest_site_options:
+        return {
+            str(o["index"] + 1): o.get("name") or f"Option {o['index'] + 1}"
+            for o in state.rest_site_options
+            if o.get("is_enabled", True)
+        }
+
+    if state.state_type == "map" and state.map_next_options:
+        sorted_nodes = sorted(state.map_next_options, key=lambda n: n["col"])
+        return {
+            str(i + 1): MAP_ROOM_LABELS.get(
+                n.get("type", "").upper(), n.get("type") or "?"
+            )
+            for i, n in enumerate(sorted_nodes)
+        }
+
+    if state.state_type in ("shop", "fake_merchant") and state.shop_items:
+        stocked = [i for i in state.shop_items if _shop_item_available(i, state)]
+        def _shop_label(item: dict) -> str:
+            category = item.get("category", "")
+            # API uses flat prefixed fields: card_name, relic_name, potion_name
+            name = (
+                item.get(f"{category}_name")
+                or item.get("name")
+                or ("Remove Card" if category == "card_removal" else None)
+                or category.replace("_", " ").title()
+                or f"Option {item['index'] + 1}"
+            )
+            price = item.get("price")
+            return f"{name} ({price}g)" if price is not None else name
+
+        labels = {str(i["index"] + 1): _shop_label(i) for i in stocked}
+        labels["end"] = "Leave"
+        return labels
+
+    if state.state_type == "relic_select" and state.relic_select_relics:
+        return {
+            str(r["index"] + 1): r.get("name") or f"Option {r['index'] + 1}"
+            for r in state.relic_select_relics
+        }
+
+    if state.state_type == "treasure" and state.treasure_relics:
+        labels = {
+            str(r["index"] + 1): r.get("name") or f"Option {r['index'] + 1}"
+            for r in state.treasure_relics
+        }
+        labels["end"] = "Proceed"
+        return labels
+
+    if state.state_type == "hand_select" and state.hand_select_cards:
+        return {
+            str(i + 1): c.get("name") or f"Option {i + 1}"
+            for i, c in enumerate(state.hand_select_cards)
+        }
+
+    if state.state_type == "card_select" and state.card_select_cards:
+        return {
+            str(i + 1): c.get("name") or f"Option {i + 1}"
+            for i, c in enumerate(state.card_select_cards)
+        }
+
+    return {}
+
+
+def preamble_for_state(state: GameState) -> str:
+    """Return the opening phrase for a vote announcement.
+
+    Most states use the generic 'Vote open!' prefix. Map gets a directional
+    note so viewers know options are numbered left to right.
+    """
+    if state.state_type == "map":
+        return "Map (left -> right):"
+    return "Vote open!"

--- a/game/options.py
+++ b/game/options.py
@@ -34,6 +34,21 @@ KNOWN_STATES: dict[str, list[str]] = {
 }
 
 
+_DEFAULT_MAX_POTION_SLOTS = 3  # STS2 default; may change with certain relics
+
+
+def _shop_item_available(item: dict, state: GameState) -> bool:
+    """Return True if a shop item can be meaningfully purchased right now."""
+    if not item.get("is_stocked", True):
+        return False
+    if not item.get("can_afford", True):
+        return False
+    # Potions can't be bought when the belt is full
+    if item.get("category") == "potion" and state.player_potion_count >= _DEFAULT_MAX_POTION_SLOTS:
+        return False
+    return True
+
+
 def options_for_state(state: GameState) -> list[str]:
     """Return the list of valid vote choices for the given game state.
 
@@ -52,6 +67,23 @@ def options_for_state(state: GameState) -> list[str]:
     if state.state_type == "hand_select" and state.hand_select_card_count:
         # Derive options from actual selectable cards; confirm is auto-sent after selection
         return [str(i + 1) for i in range(state.hand_select_card_count)]
+
+    if state.state_type == "rest_site" and state.rest_site_options:
+        # Only offer enabled options (e.g. Smith may be unavailable early)
+        enabled = [o for o in state.rest_site_options if o.get("is_enabled", True)]
+        if enabled:
+            return [str(o["index"] + 1) for o in enabled]
+
+    if state.state_type == "map" and state.map_next_options:
+        # Sort by col ascending (left → right) so !1 is always the leftmost path
+        sorted_nodes = sorted(state.map_next_options, key=lambda n: n["col"])
+        return [str(i + 1) for i in range(len(sorted_nodes))]
+
+    if state.state_type in ("shop", "fake_merchant") and state.shop_items:
+        # Only offer items that are stocked, affordable, and purchasable given current state
+        available = [i for i in state.shop_items if _shop_item_available(i, state)]
+        if available:
+            return [str(i["index"] + 1) for i in available] + ["end"]
 
     if state.state_type == "event" and state.event_options:
         # Derive options from actual event options, skipping locked ones

--- a/game/state.py
+++ b/game/state.py
@@ -15,6 +15,7 @@ class GameState:
     player_hp: int | None
     player_max_hp: int | None
     player_block: int | None = None       # player.block
+    player_potion_count: int = 0               # len(player.potions) — for shop potion availability
     player_energy: int | None = None      # player.energy (combat only)
     is_play_phase: bool | None = None          # battle.is_play_phase (combat only)
     hand_size: int | None = None               # len(player.hand) — used for mid-turn re-queue detection
@@ -25,6 +26,17 @@ class GameState:
     hand_select_card_count: int = 0                                  # len(hand_select.cards) (hand_select state only)
     rewards_items: list[dict] = field(default_factory=list)          # rewards.items (rewards state only)
     card_select_can_confirm: bool = False                             # card_select.can_confirm (card_select state only)
+    # Label data — human-readable names for vote option display
+    hand_card_names: dict[int, str] = field(default_factory=dict)    # hand index → card name (combat)
+    card_reward_names: list[str] = field(default_factory=list)       # card_reward.cards[i].name
+    rest_site_can_proceed: bool = False                               # rest_site.can_proceed
+    rest_site_options: list[dict] = field(default_factory=list)      # rest_site.options (has index, name, is_enabled)
+    map_next_options: list[dict] = field(default_factory=list)       # map.next_options (has index, col, type)
+    relic_select_relics: list[dict] = field(default_factory=list)    # relic_select.relics (has index, name)
+    treasure_relics: list[dict] = field(default_factory=list)        # treasure.relics (has index, name)
+    hand_select_cards: list[dict] = field(default_factory=list)      # hand_select.cards (has name)
+    card_select_cards: list[dict] = field(default_factory=list)      # card_select.cards (has name)
+    shop_items: list[dict] = field(default_factory=list)             # shop.items or fake_merchant.shop.items
 
     @classmethod
     def from_api_response(cls, data: dict) -> "GameState":
@@ -45,6 +57,11 @@ class GameState:
         hand_select = data.get("hand_select") or {}
         rewards = data.get("rewards") or {}
         card_select = data.get("card_select") or {}
+        card_reward_data = data.get("card_reward") or {}
+        rest_site_data = data.get("rest_site") or {}
+        map_data = data.get("map") or {}
+        relic_select_data = data.get("relic_select") or {}
+        treasure_data = data.get("treasure") or {}
 
         return cls(
             state_type=data["state_type"],
@@ -53,6 +70,7 @@ class GameState:
             player_hp=player.get("hp"),
             player_max_hp=player.get("max_hp"),
             player_block=player.get("block"),
+            player_potion_count=len(player.get("potions") or []),
             player_energy=player.get("energy"),
             is_play_phase=battle.get("is_play_phase"),
             hand_size=len(player.get("hand") or []),
@@ -65,6 +83,20 @@ class GameState:
             hand_select_card_count=len(hand_select.get("cards") or []),
             rewards_items=rewards.get("items") or [],
             card_select_can_confirm=bool(card_select.get("can_confirm")),
+            hand_card_names={c["index"]: c["name"] for c in (player.get("hand") or []) if "name" in c},
+            card_reward_names=[c["name"] for c in (card_reward_data.get("cards") or []) if "name" in c],
+            rest_site_can_proceed=bool(rest_site_data.get("can_proceed")),
+            rest_site_options=rest_site_data.get("options") or [],
+            map_next_options=map_data.get("next_options") or [],
+            relic_select_relics=relic_select_data.get("relics") or [],
+            treasure_relics=treasure_data.get("relics") or [],
+            hand_select_cards=hand_select.get("cards") or [],
+            card_select_cards=card_select.get("cards") or [],
+            shop_items=(
+                (data.get("shop") or {}).get("items")
+                or (data.get("fake_merchant") or {}).get("shop", {}).get("items")
+                or []
+            ),
         )
 
     def is_combat_state(self) -> bool:


### PR DESCRIPTION
## Summary

- Adds `game/labels.py` with `labels_for_state()` and `preamble_for_state()` — presentation layer separate from vote options logic
- Extends `GameState` with label-data fields parsed from the STS2MCP API (card names, event titles, relic names, rest site options, map nodes, shop items)
- `VoteManager.run_window()` accepts optional `labels` and `preamble` params; all three close messages (winner/random/tie) now include the winning label
- Map votes sorted left→right by `col` with `Map (left -> right):` preamble
- Dynamic options for `map`, `rest_site`, `shop` (replaces static KNOWN_STATES fallbacks)
- Shop filters out unaffordable items and potions when belt is full; shows item name + price
- Auto-proceed from `rest_site` after selecting an option (Rest/Smith)

## Live-tested
- Combat (`!1=Strike ... !end=End Turn`), event (option titles), card_reward (card names + Skip), map (room types left→right), rest_site (Rest/Smith + auto-proceed), card_select (card names)

## Remaining edge cases
Tracked in #35 — shop card names (pending live test), relic_select, treasure, hand_select.

## Test plan
- [ ] Start a run and verify combat vote shows card names
- [ ] Verify map vote shows `Map (left -> right): !1=Fight !2=Elite` etc.
- [ ] Verify event vote shows option titles
- [ ] Verify card reward shows card names + `!skip=Skip`
- [ ] Verify rest site shows option names and auto-proceeds after selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)