### PR TITLE
feat(#34): AnyEnemy target vote, hand_select race condition fix, bot launch fix

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,18 +6,18 @@
 ## Recently Completed
 - #26 — Mid-event option change detection: rewards auto-handling, dynamic options, auto-confirm; live-tested
 - #28 — Descriptive vote labels: `!N=Label` for all in-run states; `game/labels.py`; map left→right preamble; dynamic rest_site/map/shop options; shop shows name+price, filters unaffordable+full-belt potions
-  - Live-tested: combat, event, card_reward, map, rest_site, card_select
-  - Remaining edge cases tracked in #35 (shop names, relic_select, treasure, hand_select)
+  - Remaining edge cases tracked in #38 (shop names, relic_select, treasure, hand_select, polling hang)
+- #34 — Multi-target card voting: AnyEnemy → follow-up target vote with `Name (hp/max_hphp)` labels; auto-target on single enemy; `hand_select` race condition fix; bot launch vote fix
+  - Live-tested: multi-enemy (Strike/Neutralize), single-enemy (Dagger Throw auto-target), AllEnemies/Self/None skip, Dagger Throw chain (target vote → hand_select)
 
 ## Active Issue
 None
 
 ## Up Next
-1. #35 — Live-test remaining label states (shop, relic_select, treasure, hand_select)
+1. #38 — Pre-1.0 edge cases (shop labels, relic_select, treasure, hand_select, polling hang)
 2. #7 — Database Logging
 3. #9 — Production Hardening
 4. #33 — Rest site Smith: card selection via chat
-5. #34 — Combat: multi-target card voting
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)

--- a/bot/client.py
+++ b/bot/client.py
@@ -10,7 +10,7 @@ from game.actions import build_api_body
 from game.api_client import STS2Client
 from game.events import GameEndedEvent, GameEvent, GameStartedEvent, MenuSelectNeededEvent, VoteNeededEvent
 from game.menu_client import MenuClient
-from game.labels import labels_for_state, preamble_for_state
+from game.labels import labels_for_state, preamble_for_state, target_labels_for_enemies
 from game.options import options_for_state
 from game.state import GameState
 
@@ -59,6 +59,8 @@ class TwitchBot(commands.Bot):
         self._game_client = game_client
         self._menu_client = menu_client
         self.vote_manager = VoteManager(config["vote"]["duration_seconds"])
+        self._target_vote_duration: float = config["vote"]["target_duration_seconds"]
+        self._ready = asyncio.Event()  # set in event_ready; gates _event_runner
 
         super().__init__(
             client_id=config["twitch"]["client_id"],
@@ -93,6 +95,7 @@ class TwitchBot(commands.Bot):
             sender=self.bot_id,
             token_for=self.bot_id,
         )
+        self._ready.set()
 
     async def event_command_error(self, payload: commands.CommandErrorPayload) -> None:
         # !1, !end, !left, etc. are not registered commands — silence the noise.
@@ -103,6 +106,7 @@ class TwitchBot(commands.Bot):
     async def _event_runner(self) -> None:
         """Background task: dequeue GameEvents and handle each in chat."""
         logger.info("Event runner started")
+        await self._ready.wait()  # ensure event_ready has fired before sending to chat
         users = await self.fetch_users(ids=[self._owner_id])
         broadcaster: twitchio.PartialUser = users[0]
 
@@ -197,6 +201,17 @@ class TwitchBot(commands.Bot):
                         preamble=preamble_for_state(event.state),
                     )
 
+                    # AnyEnemy cards require a follow-up target vote when multiple enemies
+                    # are alive. resolved_target is passed through to build_api_body.
+                    resolved_target: str | None = None
+                    if winner.isdigit() and event.state.is_combat_state():
+                        card_index = int(winner) - 1
+                        target_type = event.state.hand_card_target_types.get(card_index, "")
+                        if target_type == "AnyEnemy":
+                            resolved_target = await self._run_target_vote(
+                                broadcaster, winner, event.state
+                            )
+
                     # Re-fetch state so action uses fresh data (e.g. enemies list
                     # may be empty on the first monster poll that queued the vote).
                     fresh_data = await self._game_client.get_state()
@@ -230,7 +245,7 @@ class TwitchBot(commands.Bot):
                         continue
 
                     try:
-                        body = build_api_body(action_state, winner)
+                        body = build_api_body(action_state, winner, target_entity_id=resolved_target)
                     except ValueError:
                         logger.error(
                             "No API mapping for state=%s winner=%s — skipping action",
@@ -282,6 +297,69 @@ class TwitchBot(commands.Bot):
                 raise
             except Exception:
                 logger.error("Unexpected error in event runner", exc_info=True)
+
+    async def _run_target_vote(
+        self,
+        broadcaster: twitchio.PartialUser,
+        card_winner: str,
+        event_state: GameState,
+    ) -> str | None:
+        """Run a follow-up target-selection vote for an AnyEnemy card.
+
+        Returns the chosen entity_id, or None if the enemy list is empty
+        (combat ended — the stale-vote guard downstream will handle it).
+        Auto-targets when only one enemy is alive (no vote needed).
+        """
+        card_index = int(card_winner) - 1
+        card_name = event_state.hand_card_names.get(card_index, f"Card {card_winner}")
+        enemies = event_state.enemies
+
+        if len(enemies) == 1:
+            logger.info("AnyEnemy card '%s' — single enemy, auto-targeting %s", card_name, enemies[0]["name"])
+            return enemies[0]["entity_id"]
+
+        if not enemies:
+            return None
+
+        target_options = [str(i + 1) for i in range(len(enemies))]
+        target_labels = target_labels_for_enemies(enemies)
+
+        target_winner = await self.vote_manager.run_window(
+            broadcaster=broadcaster,
+            bot_id=self.bot_id,
+            options=target_options,
+            state_summary=f"target select for {card_name}",
+            labels=target_labels,
+            preamble=f"{card_name} \u2014 choose target:",
+            duration=self._target_vote_duration,
+        )
+
+        # Guard: re-check enemy list after vote (theoretically impossible to change in SP)
+        guard_data = await self._game_client.get_state()
+        current_enemies = enemies
+        if guard_data:
+            try:
+                guard_state = GameState.from_api_response(guard_data)
+                if guard_state.enemies:
+                    current_enemies = guard_state.enemies
+            except ValueError:
+                pass
+
+        if len(current_enemies) == 1:
+            logger.info("Enemy list changed to 1 after target vote — auto-targeting %s", current_enemies[0]["name"])
+            return current_enemies[0]["entity_id"]
+
+        if current_enemies:
+            target_idx = int(target_winner) - 1
+            if target_idx >= len(current_enemies):
+                logger.warning(
+                    "Target index %d out of range for %d enemies — defaulting to first",
+                    target_idx, len(current_enemies),
+                )
+                target_idx = 0
+            return current_enemies[target_idx]["entity_id"]
+
+        return None  # combat ended; stale-vote guard handles it
 
     async def _handle_rewards(self) -> None:
         """Auto-claim all non-card rewards, open card rewards for a chat vote, then proceed.

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -46,6 +46,7 @@ class VoteManager:
         state_summary: str,
         labels: dict[str, str] | None = None,
         preamble: str = "Vote open!",
+        duration: float | None = None,
     ) -> str:
         """Open a vote window, collect votes, tally, announce winner.
 
@@ -57,18 +58,20 @@ class VoteManager:
         self._open = True
         logger.info("Vote window opened for state: %s", state_summary)
 
+        effective_duration = duration if duration is not None else self._duration
+
         parts = [
             f"!{o}={labels[o]}" if (labels and o in labels) else f"!{o}"
             for o in options
         ]
         options_str = "  ".join(parts)
         await broadcaster.send_message(
-            message=f"{preamble} {options_str}  ({self._duration:.0f}s)",
+            message=f"{preamble} {options_str}  ({effective_duration:.0f}s)",
             sender=bot_id,
             token_for=bot_id,
         )
 
-        await asyncio.sleep(self._duration)
+        await asyncio.sleep(effective_duration)
 
         self._open = False
         logger.info("Vote window closed. %d vote(s) cast.", len(self._votes))

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -5,7 +5,8 @@ twitch:
   channel: ""           # Your Twitch channel name
 
 vote:
-  duration_seconds: 2  # How long each voting window stays open
+  duration_seconds: 10  # How long each card/action voting window stays open
+  target_duration_seconds: 10  # How long the target selection vote stays open
 
 game:
   poll_interval_seconds: 1  # How often to check STS2 game state

--- a/game/actions.py
+++ b/game/actions.py
@@ -5,7 +5,7 @@ from game.state import GameState
 logger = logging.getLogger(__name__)
 
 
-def build_api_body(state: GameState, winner: str) -> dict:
+def build_api_body(state: GameState, winner: str, target_entity_id: str | None = None) -> dict:
     """Translate a vote winner string into a STS2MCP action request body.
 
     Vote options are 1-indexed strings (e.g. "1", "2"); the API uses 0-indexed
@@ -21,7 +21,9 @@ def build_api_body(state: GameState, winner: str) -> dict:
             # Vote number matches the 1-indexed hand position shown in-game
             card_index = int(winner) - 1
             body: dict = {"action": "play_card", "card_index": card_index}
-            if state.enemies:
+            if target_entity_id is not None:
+                body["target"] = target_entity_id
+            elif state.enemies:
                 body["target"] = state.enemies[0]["entity_id"]
             return body
         except ValueError:

--- a/game/labels.py
+++ b/game/labels.py
@@ -113,6 +113,18 @@ def labels_for_state(state: GameState) -> dict[str, str]:
     return {}
 
 
+def target_labels_for_enemies(enemies: list[dict]) -> dict[str, str]:
+    """Return {option_str: display_label} for a target-selection vote.
+
+    Labels use the format "Name (hp/max_hphp)", ordered by the enemies list
+    (left-to-right screen order as returned by the API).
+    """
+    return {
+        str(i + 1): f"{e['name']} ({e['hp']}/{e['max_hp']}hp)"
+        for i, e in enumerate(enemies)
+    }
+
+
 def preamble_for_state(state: GameState) -> str:
     """Return the opening phrase for a vote announcement.
 
@@ -121,4 +133,6 @@ def preamble_for_state(state: GameState) -> str:
     """
     if state.state_type == "map":
         return "Map (left -> right):"
+    if state.state_type == "hand_select" and state.hand_select_prompt:
+        return f"{state.hand_select_prompt.rstrip('.')}:"
     return "Vote open!"

--- a/game/polling.py
+++ b/game/polling.py
@@ -105,13 +105,40 @@ async def poll_game_state(
                             and previous_state.hand_size is not None
                             and state.hand_size < previous_state.hand_size
                         ):
-                            # Card was played mid-turn — re-queue so the next card can be voted on
-                            logger.info(
-                                "Card played mid-turn (hand %d → %d) — re-queuing vote",
-                                previous_state.hand_size,
-                                state.hand_size,
-                            )
-                            event_queue.put_nowait(VoteNeededEvent(state))
+                            # Card was played mid-turn — poll briefly before re-queuing a combat
+                            # vote. Some cards (e.g. Dagger Throw) trigger hand_select after a
+                            # short delay; exiting early avoids a stale combat vote in the queue.
+                            # Polls every 0.5s for up to 2.5s, exits as soon as state changes.
+                            recheck_state = state
+                            for _ in range(5):
+                                await asyncio.sleep(0.5)
+                                recheck_data = await client.get_state()
+                                if not recheck_data:
+                                    break
+                                try:
+                                    recheck_state = GameState.from_api_response(recheck_data)
+                                except ValueError:
+                                    break
+                                if recheck_state.state_type != state.state_type:
+                                    break  # state changed — exit early
+
+                            if recheck_state.state_type != state.state_type:
+                                # State already changed — queue new state directly, skip combat re-queue
+                                logger.info(
+                                    "State changed to '%s' after card play — queuing directly",
+                                    recheck_state.state_type,
+                                )
+                                if recheck_state.requires_player_input():
+                                    event_queue.put_nowait(VoteNeededEvent(recheck_state))
+                            else:
+                                logger.info(
+                                    "Card played mid-turn (hand %d → %d) — re-queuing vote",
+                                    previous_state.hand_size,
+                                    recheck_state.hand_size,
+                                )
+                                event_queue.put_nowait(VoteNeededEvent(recheck_state))
+                            # Update state so previous_state = state (line below) uses recheck_state
+                            state = recheck_state
                     elif state.state_type == "event":
                         curr_key = [(o.get("index"), o.get("title")) for o in state.event_options]
                         prev_key = [(o.get("index"), o.get("title")) for o in previous_state.event_options]

--- a/game/state.py
+++ b/game/state.py
@@ -24,10 +24,12 @@ class GameState:
     crystal_sphere_cells: list[dict] = field(default_factory=list)  # crystal_sphere.clickable_cells
     event_options: list[dict] = field(default_factory=list)         # event.options (event state only)
     hand_select_card_count: int = 0                                  # len(hand_select.cards) (hand_select state only)
+    hand_select_prompt: str = ""                                     # hand_select.prompt (hand_select state only)
     rewards_items: list[dict] = field(default_factory=list)          # rewards.items (rewards state only)
     card_select_can_confirm: bool = False                             # card_select.can_confirm (card_select state only)
     # Label data — human-readable names for vote option display
-    hand_card_names: dict[int, str] = field(default_factory=dict)    # hand index → card name (combat)
+    hand_card_names: dict[int, str] = field(default_factory=dict)        # hand index → card name (combat)
+    hand_card_target_types: dict[int, str] = field(default_factory=dict) # hand index → target_type (combat)
     card_reward_names: list[str] = field(default_factory=list)       # card_reward.cards[i].name
     rest_site_can_proceed: bool = False                               # rest_site.can_proceed
     rest_site_options: list[dict] = field(default_factory=list)      # rest_site.options (has index, name, is_enabled)
@@ -81,9 +83,11 @@ class GameState:
             crystal_sphere_cells=crystal_sphere.get("clickable_cells") or [],
             event_options=event.get("options") or [],
             hand_select_card_count=len(hand_select.get("cards") or []),
+            hand_select_prompt=hand_select.get("prompt") or "",
             rewards_items=rewards.get("items") or [],
             card_select_can_confirm=bool(card_select.get("can_confirm")),
             hand_card_names={c["index"]: c["name"] for c in (player.get("hand") or []) if "name" in c},
+            hand_card_target_types={c["index"]: c["target_type"] for c in (player.get("hand") or []) if "target_type" in c},
             card_reward_names=[c["name"] for c in (card_reward_data.get("cards") or []) if "name" in c],
             rest_site_can_proceed=bool(rest_site_data.get("can_proceed")),
             rest_site_options=rest_site_data.get("options") or [],


### PR DESCRIPTION
## Summary
- After a card vote resolves for an `AnyEnemy` card, a follow-up target vote opens labeled with `Name (hp/max_hphp)` ordered left-to-right; auto-targets when only one enemy is alive
- `AllEnemies`, `Self`, and `None` cards skip the target vote entirely
- Target vote duration is configurable (`vote.target_duration_seconds: 10`)
- `hand_select` preamble now uses the game's prompt text (e.g. `Choose a card to Discard:`) instead of generic `Vote open!`
- Polling recheck loop (5×0.5s, early exit on state change) prevents a stale combat vote from queuing when a card triggers `hand_select` (e.g. Dagger Throw, Survivor, Prepared)
- Event runner now waits for `event_ready` before processing votes, fixing the missing vote announcement on bot launch

## Test plan
- [x] Multi-enemy combat: AnyEnemy card → target vote opens with correct labels → correct enemy takes damage
- [x] Single-enemy combat: AnyEnemy card → auto-targets, no target vote
- [x] AllEnemies/Self/None cards (Haze, Defend, Survivor, Speedster) → no target vote, play immediately
- [x] Dagger Throw chain: target vote → card plays → `Choose a card to Discard:` opens immediately
- [x] Survivor chain: `Choose a card to Discard:` opens immediately after play
- [x] Bot launch: vote announcement appears in chat right after `Bot is online!`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)