### PR TITLE
fix(#47): resolve silent stops across treasure, rest_site, shop, and combat

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,10 +4,10 @@
 `PoC`
 
 ## Recently Completed
+- #47 — Silent stops: auto-proceed treasure/rest_site; shop re-queue + leave-only fallback; playable_card_indices change detection (relic card draw); diagnostic DEBUG logging; live-tested
 - #33 — Smith upgrade: deck-wide card vote; dedup identical copies (e.g. `Defend (x5)`); numbered `!N` voting; 30s window; green announcement header; select_card + confirm_selection flow; live-tested
 - #28 — Descriptive vote labels: `!N=Label` for all in-run states; `game/labels.py`; map left→right preamble; dynamic rest_site/map/shop options; shop shows name+price, filters unaffordable+full-belt potions
 - #34 — Multi-target card voting: AnyEnemy → follow-up target vote with `Name (hp/max_hphp)` labels; auto-target on single enemy; `hand_select` race condition fix; bot launch vote fix
-- #32 — Card lookup: `((name))` searches all piles → name+cost+description+wiki.gg link; `?N` looks up hand slot N; multi-card in one message; works at any game state; live-tested
 
 ## Active Issue
 None

--- a/bot/client.py
+++ b/bot/client.py
@@ -247,7 +247,9 @@ class TwitchBot(commands.Bot):
 
         while True:
             try:
+                logger.debug("Event runner: waiting for event (queue size=%d)", self._event_queue.qsize())
                 event: GameEvent = await self._event_queue.get()
+                logger.info("Event runner: processing %s", type(event).__name__)
 
                 if isinstance(event, GameStartedEvent):
                     logger.info("Game started: %s", event.state.summary())
@@ -423,8 +425,37 @@ class TwitchBot(commands.Bot):
                     else:
                         logger.info("Action executed: %s → %s", winner, result)
 
+                    # shop/fake_merchant: re-queue vote after successful purchase — player may want to buy more
+                    if action_state.state_type in ("shop", "fake_merchant") and body.get("action") == "shop_purchase" and result is not None:
+                        post_shop_data = await self._game_client.get_state()
+                        if post_shop_data:
+                            try:
+                                post_shop_state = GameState.from_api_response(post_shop_data)
+                                if post_shop_state.state_type == action_state.state_type:
+                                    logger.info("Shop purchase complete — re-queuing vote")
+                                    self._event_queue.put_nowait(VoteNeededEvent(post_shop_state))
+                            except ValueError:
+                                pass
+
+                    # rest_site: auto-proceed after choosing an option (Rest/Smith/etc.)
+                    if action_state.state_type == "rest_site" and body.get("action") == "choose_rest_option":
+                        post_rest_data = await self._game_client.get_state()
+                        if post_rest_data:
+                            try:
+                                post_rest_state = GameState.from_api_response(post_rest_data)
+                                if post_rest_state.state_type == "rest_site" and post_rest_state.rest_site_can_proceed:
+                                    proceed_result = await self._game_client.post_action({"action": "proceed"})
+                                    logger.info("Auto-proceeded after rest_site option → %s", proceed_result)
+                            except ValueError:
+                                pass
+
+                    # treasure: auto-proceed after relic claim — game stays in treasure state
+                    elif action_state.state_type == "treasure" and body.get("action") == "claim_treasure_relic":
+                        proceed_result = await self._game_client.post_action({"action": "proceed"})
+                        logger.info("Auto-proceeded after treasure relic claim → %s", proceed_result)
+
                     # hand_select: auto-confirm after card selection — no second vote needed
-                    if action_state.state_type == "hand_select" and body.get("action") == "combat_select_card":
+                    elif action_state.state_type == "hand_select" and body.get("action") == "combat_select_card":
                         confirm_result = await self._game_client.post_action({"action": "combat_confirm_selection"})
                         logger.info("Auto-confirmed hand_select → %s", confirm_result)
 

--- a/game/options.py
+++ b/game/options.py
@@ -79,11 +79,12 @@ def options_for_state(state: GameState) -> list[str]:
         sorted_nodes = sorted(state.map_next_options, key=lambda n: n["col"])
         return [str(i + 1) for i in range(len(sorted_nodes))]
 
-    if state.state_type in ("shop", "fake_merchant") and state.shop_items:
+    if state.state_type in ("shop", "fake_merchant"):
         # Only offer items that are stocked, affordable, and purchasable given current state
         available = [i for i in state.shop_items if _shop_item_available(i, state)]
         if available:
             return [str(i["index"] + 1) for i in available] + ["end"]
+        return ["end"]  # no purchasable items — only option is to leave
 
     if state.state_type == "event" and state.event_options:
         # Derive options from actual event options, skipping locked ones

--- a/game/polling.py
+++ b/game/polling.py
@@ -88,12 +88,17 @@ async def poll_game_state(
                     elif state.requires_player_input():
                         logger.info("Queuing vote for state: %s", state.state_type)
                         event_queue.put_nowait(VoteNeededEvent(state))
+                    else:
+                        logger.info("State '%s' does not require player input — no vote queued", state.state_type)
                     previous_state = state
 
                 else:
                     # Same state_type — check for within-state changes
                     _log_within_state_changes(previous_state, state)
-                    if state.is_combat_state() and state.is_play_phase:
+                    logger.debug("Poll: same state '%s'", state.state_type)
+                    if state.is_combat_state() and not state.is_play_phase:
+                        logger.debug("Combat '%s': enemy turn (is_play_phase=False)", state.state_type)
+                    elif state.is_combat_state() and state.is_play_phase:
                         if not previous_state.is_play_phase:
                             # Edge: enemy turn → player turn (caught by poller)
                             logger.info(
@@ -118,11 +123,12 @@ async def poll_game_state(
                             state.hand_size is not None
                             and previous_state.hand_size is not None
                             and state.hand_size < previous_state.hand_size
+                        ) or (
+                            set(state.playable_card_indices) != set(previous_state.playable_card_indices)
                         ):
-                            # Card was played mid-turn — poll briefly before re-queuing a combat
-                            # vote. Some cards (e.g. Dagger Throw) trigger hand_select after a
-                            # short delay; exiting early avoids a stale combat vote in the queue.
-                            # Polls every 0.5s for up to 2.5s, exits as soon as state changes.
+                            # Card was played mid-turn, or playable cards changed (e.g. relic drew
+                            # a card, restoring hand size). Poll briefly before re-queuing — some
+                            # cards (e.g. Dagger Throw) trigger hand_select after a short delay.
                             recheck_state = state
                             for _ in range(5):
                                 await asyncio.sleep(0.5)
@@ -153,6 +159,13 @@ async def poll_game_state(
                                 event_queue.put_nowait(VoteNeededEvent(recheck_state))
                             # Update state so previous_state = state (line below) uses recheck_state
                             state = recheck_state
+                        else:
+                            logger.debug(
+                                "Combat '%s': player turn, no new-turn trigger (round=%s, hand=%s)",
+                                state.state_type,
+                                state.battle_round,
+                                state.hand_size,
+                            )
                     elif state.state_type == "event":
                         curr_key = [(o.get("index"), o.get("title")) for o in state.event_options]
                         prev_key = [(o.get("index"), o.get("title")) for o in previous_state.event_options]


### PR DESCRIPTION
## Summary
- Auto-proceed after `claim_treasure_relic` — game stays in `treasure` state after claiming, bot wasn't hitting proceed
- Auto-proceed after `choose_rest_option` when `can_proceed=True` — same root cause at rest sites
- Re-queue shop vote after successful purchase; return `["end"]` when no items available — prevented infinite fallback loop on empty `shop_items`
- Detect `playable_card_indices` changes in poller — relic card draws that restore hand size were silently skipping the next combat vote
- Add `DEBUG` logging to polling loop and event runner for future diagnostics

## Root cause
All stalls shared the same pattern: after an action, the game's `state_type` didn't change, so the poller never re-queued a vote. Each fix adds a post-action re-queue or detection path for the affected state.

## Test plan
- [x] Treasure room: relic claimed → auto-proceeded to map
- [x] Rest site: Rested → auto-proceeded to map
- [x] Shop: purchased item → re-queued vote with updated items; empty shop → only `!end` offered
- [x] Combat: Shiv killed enemy, relic drew card restoring hand size → new vote queued with all playable cards

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)