### PR TITLE
feat(#59): promote hardcoded timings and retry counts to settings.yaml

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,21 +4,20 @@
 `PoC`
 
 ## Recently Completed
+- #59 — All 7 hardcoded timings/retries promoted to settings.yaml; threaded through loader, clients, polling, options, bot
 - #62 — 165-test suite: state/actions/options/labels/polling/api_client/vote_manager; runs via `python -m pytest`, no live deps
 - #58 — Refactor _event_runner (379 lines) into 9 focused methods; _event_runner now 45 lines; fixed polling bug for draw-on-play cards
 - #56 — !help command (any time, not vote-gated) + README (setup, .env, mods, commands cheat sheet); live-tested
-- #51 — Potions: use/discard voting (!pN/!dN), belt filter in shop, AnyEnemy target vote, ?potions/?p command, dry-run mode
 
 ## Active Issue
 None
 
 ## Up Next
-1. #59 — Move hardcoded timings/retries to settings.yaml
-2. #60 — Chat-send DRY + broadcaster caching
-3. #53 — Full belt + potion reward: discard-to-claim flow
-4. #63 — End-game screen navigation (victory, defeat, unlocks)
-5. #7 — Database Logging
-6. #61 — Bundled minor code-hygiene cleanups
+1. #60 — Chat-send DRY + broadcaster caching
+2. #53 — Full belt + potion reward: discard-to-claim flow
+3. #63 — End-game screen navigation (victory, defeat, unlocks)
+4. #7 — Database Logging
+5. #61 — Bundled minor code-hygiene cleanups
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,27 @@ Bot token required scopes: `user:read:chat user:write:chat user:bot moderator:ma
 
 ### 3. Configure settings
 
-Edit `config/settings.yaml` to adjust vote durations, poll interval, etc. The defaults are reasonable for most setups.
+Edit `config/settings.yaml` to tune behavior. Defaults are reasonable for most setups.
+
+| Section | Key | Default | Description |
+|---|---|---|---|
+| `vote` | `duration_seconds` | `10` | Vote window length |
+| `vote` | `target_duration_seconds` | `10` | Target-selection vote length |
+| `vote` | `smith_vote_duration_seconds` | `30` | Smith upgrade vote length |
+| `game` | `poll_interval_seconds` | `1` | How often to poll game state |
+| `game` | `dry_run` | `false` | Log actions without sending to game |
+| `game` | `auto_proceed_delay_seconds` | `3` | Pause before auto-proceeding single-option screens |
+| `game` | `rest_site_poll_attempts` | `10` | Max polls waiting for rest site to allow proceed |
+| `game` | `rest_site_poll_interval_seconds` | `1.0` | Interval between rest site polls |
+| `game` | `mid_turn_recheck_attempts` | `5` | Extra polls after a card play or potion use |
+| `game` | `mid_turn_recheck_interval_seconds` | `0.5` | Interval between mid-turn rechecks |
+| `game` | `action_retry_count` | `1` | Retries on a failed action POST |
+| `api` | `http_timeout_seconds` | `5.0` | HTTP timeout for game/menu API calls |
+| `menu` | `initial_query_retry_attempts` | `5` | Retries when MenuControl may still be initializing |
+| `menu` | `initial_query_retry_interval_seconds` | `1.0` | Interval between initial query retries |
+| `menu` | `transition_retry_attempts` | `3` | Retries waiting for CHARACTER_SELECT after menu open |
+| `menu` | `transition_retry_interval_seconds` | `0.5` | Interval between transition retries |
+| `potions` | `max_belt_size` | `3` | Belt capacity (until the API exposes it directly) |
 
 ### 4. Install STS2 mods
 

--- a/bot/client.py
+++ b/bot/client.py
@@ -290,6 +290,18 @@ class TwitchBot(commands.Bot):
         self._target_vote_duration: float = config["vote"]["target_duration_seconds"]
         self._smith_vote_duration: float = config["vote"].get("smith_vote_duration_seconds", 30.0)
         self._auto_proceed_delay: float = config["game"].get("auto_proceed_delay_seconds", 3.0)
+
+        game_cfg = config["game"]
+        menu_cfg = config.get("menu", {})
+        self._rest_site_poll_attempts: int = game_cfg.get("rest_site_poll_attempts", 10)
+        self._rest_site_poll_interval: float = game_cfg.get("rest_site_poll_interval_seconds", 1.0)
+        self._action_retry_count: int = game_cfg.get("action_retry_count", 1)
+        self._max_belt_size: int = config.get("potions", {}).get("max_belt_size", 3)
+        self._menu_initial_retry_attempts: int = menu_cfg.get("initial_query_retry_attempts", 5)
+        self._menu_initial_retry_interval: float = menu_cfg.get("initial_query_retry_interval_seconds", 1.0)
+        self._menu_transition_retry_attempts: int = menu_cfg.get("transition_retry_attempts", 3)
+        self._menu_transition_retry_interval: float = menu_cfg.get("transition_retry_interval_seconds", 0.5)
+
         self._ready = asyncio.Event()  # set in event_ready; gates _event_runner
 
         super().__init__(
@@ -476,7 +488,7 @@ class TwitchBot(commands.Bot):
             return True
 
         # Shop/fake_merchant with nothing purchasable — no vote needed
-        if state.state_type in ("shop", "fake_merchant") and options_for_state(state) == ["end"]:
+        if state.state_type in ("shop", "fake_merchant") and options_for_state(state, max_belt_size=self._max_belt_size) == ["end"]:
             result = await self._game_client.post_action({"action": "proceed"})
             logger.info("Auto-left shop — nothing purchasable → %s", result)
             return True
@@ -535,7 +547,7 @@ class TwitchBot(commands.Bot):
         winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,
-            options=options_for_state(vote_state),
+            options=options_for_state(vote_state, max_belt_size=self._max_belt_size),
             state_summary=vote_state.summary(),
             labels=labels_for_state(vote_state) or None,
             preamble=preamble_for_state(vote_state),
@@ -583,18 +595,19 @@ class TwitchBot(commands.Bot):
         return None
 
     async def _post_action_with_retry(self, body: dict, winner: str) -> dict | None:
-        """POST an action to the game API; retry once on failure."""
+        """POST an action to the game API; retry up to action_retry_count times on failure."""
         result = await self._game_client.post_action(body)
-        if result is None:
-            logger.warning("Action POST failed, retrying once...")
-            result = await self._game_client.post_action(body)
-            if result is None:
-                logger.error("Action POST failed twice for body=%s — system may be stuck", body)
-            else:
-                logger.info("Action executed (retry): %s → %s", winner, result)
-        else:
+        if result is not None:
             logger.info("Action executed: %s → %s", winner, result)
-        return result
+            return result
+        for attempt in range(1, self._action_retry_count + 1):
+            logger.warning("Action POST failed, retrying (attempt %d/%d)...", attempt, self._action_retry_count)
+            result = await self._game_client.post_action(body)
+            if result is not None:
+                logger.info("Action executed (retry %d): %s → %s", attempt, winner, result)
+                return result
+        logger.error("Action POST failed after %d retries for body=%s — system may be stuck", self._action_retry_count, body)
+        return None
 
     async def _handle_post_action(
         self,
@@ -620,8 +633,8 @@ class TwitchBot(commands.Bot):
 
         # rest_site: after choosing an option, poll until can_proceed=True then decide
         if action_state.state_type == "rest_site" and action == "choose_rest_option":
-            for _ in range(10):
-                await asyncio.sleep(1.0)
+            for _ in range(self._rest_site_poll_attempts):
+                await asyncio.sleep(self._rest_site_poll_interval)
                 post_rest_state = await self._fetch_parsed_state()
                 if post_rest_state is None:
                     break
@@ -642,7 +655,7 @@ class TwitchBot(commands.Bot):
                         logger.info("Auto-proceeded after rest_site option → %s", proceed_result)
                     break
             else:
-                logger.warning("rest_site: can_proceed never became True after 10s — may be stuck")
+                logger.warning("rest_site: can_proceed never became True after %d polls — may be stuck", self._rest_site_poll_attempts)
 
         # hand_select: confirm when can_confirm=True, re-queue if more selections needed
         elif action_state.state_type == "hand_select" and action == "combat_select_card":
@@ -919,11 +932,11 @@ class TwitchBot(commands.Bot):
         """Handle a MenuSelectNeededEvent: navigate to character select, run vote, embark."""
         # Retry initial query — MenuControl may still be initializing when STS2MCP first reports menu
         menu_data = None
-        for _ in range(5):
+        for _ in range(self._menu_initial_retry_attempts):
             menu_data = await self._menu_client.get_menu_state()
             if menu_data and menu_data.get("screen") not in (None, "UNKNOWN", "IN_GAME"):
                 break
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(self._menu_initial_retry_interval)
         if not menu_data:
             logger.warning("MenuControl API unreachable — skipping character select vote")
             return
@@ -945,8 +958,8 @@ class TwitchBot(commands.Bot):
                 return
 
             # Re-query with retries — open_character_select may need a moment to transition
-            for _ in range(3):
-                await asyncio.sleep(0.5)
+            for _ in range(self._menu_transition_retry_attempts):
+                await asyncio.sleep(self._menu_transition_retry_interval)
                 menu_data = await self._menu_client.get_menu_state()
                 if menu_data and menu_data.get("screen") == "CHARACTER_SELECT":
                     screen = "CHARACTER_SELECT"

--- a/config/loader.py
+++ b/config/loader.py
@@ -50,7 +50,10 @@ def load_config() -> dict:
         "api": {
             "sts2mcp_base_url": os.environ["STS2MCP_BASE_URL"],
             "sts2_menu_base_url": os.environ["STS2_MENU_BASE_URL"],
+            **settings.get("api", {}),
         },
         "vote": settings.get("vote", {}),
         "game": settings.get("game", {}),
+        "menu": settings.get("menu", {}),
+        "potions": settings.get("potions", {}),
     }

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -13,10 +13,25 @@ game:
   poll_interval_seconds: 1     # How often to check STS2 game state
   dry_run: false               # true = votes run normally but actions are never sent to the game API
   auto_proceed_delay_seconds: 3  # Pause before auto-proceeding single-option screens (event/map/treasure)
+  rest_site_poll_attempts: 10        # Max polls waiting for can_proceed=True after a rest-site choice
+  rest_site_poll_interval_seconds: 1.0
+  mid_turn_recheck_attempts: 5       # Extra polls after a card play / potion to catch immediate state changes
+  mid_turn_recheck_interval_seconds: 0.5
+  action_retry_count: 1              # How many times to retry a failed action POST
 
 api:
   sts2mcp_base_url: ""     # Required — set STS2MCP_BASE_URL in .env
   sts2_menu_base_url: ""   # Required — set STS2_MENU_BASE_URL in .env
+  http_timeout_seconds: 5.0  # HTTP client timeout for all game/menu API calls
+
+menu:
+  initial_query_retry_attempts: 5     # Retries when MenuControl may still be initializing
+  initial_query_retry_interval_seconds: 1.0
+  transition_retry_attempts: 3        # Retries waiting for CHARACTER_SELECT after open_character_select
+  transition_retry_interval_seconds: 0.5
+
+potions:
+  max_belt_size: 3  # STS2 default belt capacity (until the API exposes it directly)
 
 database:
   path: "data/game_history.db"

--- a/game/api_client.py
+++ b/game/api_client.py
@@ -6,9 +6,9 @@ logger = logging.getLogger(__name__)
 
 
 class STS2Client:
-    def __init__(self, base_url: str, dry_run: bool = False) -> None:
+    def __init__(self, base_url: str, dry_run: bool = False, http_timeout: float = 5.0) -> None:
         self._base_url = base_url.rstrip("/")
-        self._http = httpx.AsyncClient(timeout=5.0)
+        self._http = httpx.AsyncClient(timeout=http_timeout)
         self.dry_run = dry_run
 
     async def close(self) -> None:

--- a/game/menu_client.py
+++ b/game/menu_client.py
@@ -6,9 +6,9 @@ logger = logging.getLogger(__name__)
 
 
 class MenuClient:
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, http_timeout: float = 5.0) -> None:
         self._base_url = base_url.rstrip("/")
-        self._http = httpx.AsyncClient(timeout=5.0)
+        self._http = httpx.AsyncClient(timeout=http_timeout)
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/game/options.py
+++ b/game/options.py
@@ -102,19 +102,19 @@ def potion_vote_entries(state: GameState) -> tuple[list[tuple[str, str]], list[t
     return use_entries, discard_entries
 
 
-def _shop_item_available(item: dict, state: GameState) -> bool:
+def _shop_item_available(item: dict, state: GameState, max_belt_size: int = _DEFAULT_MAX_POTION_SLOTS) -> bool:
     """Return True if a shop item can be meaningfully purchased right now."""
     if not item.get("is_stocked", True):
         return False
     if not item.get("can_afford", True):
         return False
     # Potions can't be bought when the belt is full
-    if item.get("category") == "potion" and len(state.player_potions) >= _DEFAULT_MAX_POTION_SLOTS:
+    if item.get("category") == "potion" and len(state.player_potions) >= max_belt_size:
         return False
     return True
 
 
-def options_for_state(state: GameState) -> list[str]:
+def options_for_state(state: GameState, max_belt_size: int = _DEFAULT_MAX_POTION_SLOTS) -> list[str]:
     """Return the list of valid vote choices for the given game state.
 
     For combat states (monster/elite/boss), options are derived from the actual
@@ -124,12 +124,12 @@ def options_for_state(state: GameState) -> list[str]:
     fallback so voting is never completely blocked. Add new state_types to
     KNOWN_STATES in this module as they are discovered through live testing.
     """
-    base = _base_options_for_state(state)
+    base = _base_options_for_state(state, max_belt_size=max_belt_size)
     use_entries, discard_entries = potion_vote_entries(state)
     return base + [tag for tag, _ in use_entries] + [tag for tag, _ in discard_entries]
 
 
-def _base_options_for_state(state: GameState) -> list[str]:
+def _base_options_for_state(state: GameState, max_belt_size: int = _DEFAULT_MAX_POTION_SLOTS) -> list[str]:
     if state.is_combat_state():
         # Use actual hand positions (1-indexed) so chat options match the in-game card numbers
         numeric = [str(idx + 1) for idx in state.playable_card_indices]
@@ -152,7 +152,7 @@ def _base_options_for_state(state: GameState) -> list[str]:
 
     if state.state_type in ("shop", "fake_merchant"):
         # Only offer items that are stocked, affordable, and purchasable given current state
-        available = [i for i in state.shop_items if _shop_item_available(i, state)]
+        available = [i for i in state.shop_items if _shop_item_available(i, state, max_belt_size)]
         if available:
             return [str(i["index"] + 1) for i in available] + ["end"]
         return ["end"]  # no purchasable items — only option is to leave

--- a/game/polling.py
+++ b/game/polling.py
@@ -46,6 +46,8 @@ async def poll_game_state(
     client: STS2Client,
     interval: float,
     event_queue: asyncio.Queue[GameEvent],
+    recheck_attempts: int = 5,
+    recheck_interval: float = 0.5,
 ) -> None:
     """Poll STS2MCP every `interval` seconds and emit typed GameEvents on state transitions."""
     previous_state: GameState | None = None
@@ -144,8 +146,8 @@ async def poll_game_state(
                             # some cards (e.g. Dagger Throw) or potions may trigger hand_select
                             # after a short delay.
                             recheck_state = state
-                            for _ in range(5):
-                                await asyncio.sleep(0.5)
+                            for _ in range(recheck_attempts):
+                                await asyncio.sleep(recheck_interval)
                                 recheck_data = await client.get_state()
                                 if not recheck_data:
                                     break

--- a/main.py
+++ b/main.py
@@ -34,8 +34,9 @@ async def main() -> None:
     if dry_run:
         logger.warning("DRY RUN MODE — actions will be logged but NOT sent to the game API")
 
-    game_client = STS2Client(config["api"]["sts2mcp_base_url"], dry_run=dry_run)
-    menu_client = MenuClient(config["api"]["sts2_menu_base_url"])
+    http_timeout = config["api"].get("http_timeout_seconds", 5.0)
+    game_client = STS2Client(config["api"]["sts2mcp_base_url"], dry_run=dry_run, http_timeout=http_timeout)
+    menu_client = MenuClient(config["api"]["sts2_menu_base_url"], http_timeout=http_timeout)
 
     state = await game_client.get_state()
     if state is not None:
@@ -54,11 +55,14 @@ async def main() -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     interval = config["game"]["poll_interval_seconds"]
+    recheck_attempts = config["game"].get("mid_turn_recheck_attempts", 5)
+    recheck_interval = config["game"].get("mid_turn_recheck_interval_seconds", 0.5)
     event_queue: asyncio.Queue[GameEvent] = asyncio.Queue()
 
     async with TwitchBot(config, event_queue, game_client, menu_client) as bot:
         poll_task = asyncio.create_task(
-            poll_game_state(game_client, interval, event_queue)
+            poll_game_state(game_client, interval, event_queue,
+                            recheck_attempts=recheck_attempts, recheck_interval=recheck_interval)
         )
         try:
             await bot.start()


### PR DESCRIPTION
## Summary
- Moves all 7 hardcoded timing/retry constants to `config/settings.yaml` with defaults matching prior values (no behavior change)
- Threads values through `config/loader.py`, both API clients, `game/polling.py`, `game/options.py`, `bot/client.py`, and `main.py`
- Adds a 17-row settings reference table to README

## Test plan
- [x] `python -m pytest` — 165/165 passed
- [x] Code review: no residual hardcoded literals at any of the 7 original call sites
- [ ] Live bot run to confirm startup with new config keys loads without error

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)