### PR TITLE
feat(#59): promote hardcoded timings, retries, and logging levels to settings.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Edit `config/settings.yaml` to tune behavior. Defaults are reasonable for most s
 | `menu` | `transition_retry_attempts` | `3` | Retries waiting for CHARACTER_SELECT after menu open |
 | `menu` | `transition_retry_interval_seconds` | `0.5` | Interval between transition retries |
 | `potions` | `max_belt_size` | `3` | Belt capacity (until the API exposes it directly) |
+| `logging` | `level` | `"INFO"` | Bot log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `logging` | `twitchio_level` | `"WARNING"` | Log level for TwitchIO internals |
+| `logging` | `httpx_level` | `"WARNING"` | Log level for httpx internals |
 
 ### 4. Install STS2 mods
 

--- a/config/loader.py
+++ b/config/loader.py
@@ -56,4 +56,5 @@ def load_config() -> dict:
         "game": settings.get("game", {}),
         "menu": settings.get("menu", {}),
         "potions": settings.get("potions", {}),
+        "logging": settings.get("logging", {}),
     }

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -33,5 +33,10 @@ menu:
 potions:
   max_belt_size: 3  # STS2 default belt capacity (until the API exposes it directly)
 
+logging:
+  level: "INFO"             # Bot log level (DEBUG, INFO, WARNING, ERROR)
+  twitchio_level: "WARNING" # Suppress verbose TwitchIO output
+  httpx_level: "WARNING"    # Suppress verbose httpx output
+
 database:
   path: "data/game_history.db"

--- a/main.py
+++ b/main.py
@@ -30,6 +30,9 @@ async def main() -> None:
         logger.error("Startup failed: %s", e)
         sys.exit(1)
 
+    log_cfg = config.get("logging", {})
+    logging.getLogger().setLevel(log_cfg.get("level", "INFO"))
+
     dry_run = bool(config["game"].get("dry_run", False))
     if dry_run:
         logger.warning("DRY RUN MODE — actions will be logged but NOT sent to the game API")
@@ -51,8 +54,8 @@ async def main() -> None:
         logger.warning("MenuControl API not reachable at startup — character select will retry when needed")
 
     # Quieten verbose third-party loggers
-    logging.getLogger("twitchio").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("twitchio").setLevel(log_cfg.get("twitchio_level", "WARNING"))
+    logging.getLogger("httpx").setLevel(log_cfg.get("httpx_level", "WARNING"))
 
     interval = config["game"]["poll_interval_seconds"]
     recheck_attempts = config["game"].get("mid_turn_recheck_attempts", 5)


### PR DESCRIPTION
## Summary
- Moves all 7 timing/retry constants and 3 logging levels to `config/settings.yaml` with defaults matching prior hardcoded values (no behavior change)
- Threads values through `config/loader.py`, both API clients, `game/polling.py`, `game/options.py`, `bot/client.py`, and `main.py`
- Adds a 20-row settings reference table to README

## Test plan
- [x] `python -m pytest` — 165/165 passed
- [x] Code review: no residual hardcoded literals at any call site
- [ ] Live bot run to confirm startup with new config keys loads without error

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)