### PR TITLE
feat(#53): belt-full potion discard-to-claim vote

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,8 @@
 `PoC`
 
 ## Recently Completed
-- #60 — DRY chat-send: `_chat()` helper, `self.broadcaster` cached once, all send sites unified, `ChatComponent` no longer fetches users or touches private attrs; live-tested
-- #69 — Polling fix: draw-card effects (e.g. Soul) now always trigger re-vote via `asyncio.Event` signal from action POST + `hand_size != previous` condition
+- #53 — Belt-full potion reward: discard-to-claim vote (`_handle_belt_full_potion_discard`); skip tracking in rewards loop; `_tally` fix (skip never random); event vote retry fix; game-started as announcement
+- #60 — DRY chat-send: `_chat()` helper, `self.broadcaster` cached once, all send sites unified; live-tested
 - #59 — All 7 hardcoded timings/retries promoted to settings.yaml; threaded through loader, clients, polling, options, bot
 - #62 — 165-test suite: state/actions/options/labels/polling/api_client/vote_manager; runs via `python -m pytest`, no live deps
 
@@ -13,7 +13,7 @@
 None
 
 ## Up Next
-1. #53 — Full belt + potion reward: discard-to-claim flow
+1. #71 — Live test: belt-full potion discard-to-claim + session untested changes
 2. #63 — End-game screen navigation (victory, defeat, unlocks)
 3. #7 — Database Logging
 4. #61 — Bundled minor code-hygiene cleanups

--- a/bot/client.py
+++ b/bot/client.py
@@ -12,7 +12,7 @@ from game.api_client import STS2Client
 from game.events import GameEndedEvent, GameEvent, GameStartedEvent, MenuSelectNeededEvent, VoteNeededEvent
 from game.menu_client import MenuClient
 from game.labels import MAP_ROOM_LABELS, labels_for_state, preamble_for_state, target_labels_for_enemies
-from game.options import options_for_state, parse_potion_winner, potion_display_name
+from game.options import options_for_state, parse_potion_winner, potion_display_name, potion_vote_entries
 from game.state import GameState, IDLE_STATES
 
 logger = logging.getLogger(__name__)
@@ -359,7 +359,17 @@ class TwitchBot(commands.Bot):
 
                 if isinstance(event, GameStartedEvent):
                     logger.info("Game started: %s", event.state.summary())
-                    await self._chat("A new run has started! Type !<choice> to vote when prompted.")
+                    try:
+                        await broadcaster.send_announcement(
+                            moderator=self.bot_id,
+                            message="A new run has started! Type !<choice> to vote when prompted.",
+                            color="purple",
+                        )
+                    except twitchio.HTTPException as exc:
+                        logger.warning(
+                            "GameStarted: send_announcement failed (%s) — falling back to chat message.", exc
+                        )
+                        await self._chat("A new run has started! Type !<choice> to vote when prompted.")
                 elif isinstance(event, GameEndedEvent):
                     logger.info("Game ended: %s", event.state.summary())
                     await self._chat("Run over! Thanks for playing.")
@@ -522,6 +532,17 @@ class TwitchBot(commands.Bot):
                 return
 
         vote_state = pre_vote_state if pre_vote_state is not None else event.state
+
+        # Event options may not be populated immediately after room transition — retry briefly.
+        if vote_state.state_type == "event" and not vote_state.event_options:
+            for _ in range(3):
+                await asyncio.sleep(0.5)
+                fresh = await self._fetch_parsed_state()
+                if fresh and fresh.event_options:
+                    vote_state = fresh
+                    break
+            else:
+                logger.warning("Event state has no options after retries — falling back to static options")
         winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,
@@ -870,9 +891,49 @@ class TwitchBot(commands.Bot):
             duration=duration,
         )
 
+    async def _handle_belt_full_potion_discard(self, state: GameState, potion_item: dict) -> str:
+        """Vote to discard a held potion to claim a belt-full potion reward, or skip it.
+
+        Returns "skip" if chat skips, or the winning "dN" tag otherwise.
+        On a discard win, executes the discard and claims the reward before returning.
+        """
+        _, discard_entries = potion_vote_entries(state)
+        options = [tag for tag, _ in discard_entries] + ["skip"]
+        labels = {tag: name for tag, name in discard_entries}
+        labels["skip"] = "Skip potion reward"
+        reward_name = potion_item.get("description") or "potion"
+        preamble = f"Belt full! Discard a potion to claim {reward_name}, or !skip to pass."
+
+        winner = await self.vote_manager.run_window(
+            broadcaster=self.broadcaster,
+            bot_id=self.bot_id,
+            options=options,
+            state_summary="rewards belt-full discard",
+            labels=labels,
+            preamble=preamble,
+        )
+
+        if winner == "skip":
+            logger.info("Belt-full discard: skipping potion reward")
+            return "skip"
+
+        potion_action = parse_potion_winner(winner)
+        if potion_action and potion_action[0] == "discard":
+            slot = potion_action[1]
+            result = await self._game_client.post_action({"action": "discard_potion", "slot": slot})
+            logger.info("Belt-full discard: discarded slot %d → %s", slot, result)
+            await asyncio.sleep(self._auto_proceed_delay)
+            result = await self._game_client.post_action(
+                {"action": "claim_reward", "index": potion_item["index"]}
+            )
+            logger.info("Belt-full discard: claimed potion reward → %s", result)
+
+        return winner
+
     async def _handle_rewards(self) -> None:
         """Auto-claim gold/relic/potion rewards, open card rewards for a chat vote, then proceed."""
         _VOTE_TYPES = {"card", "special_card", "card_removal"}
+        skipped_indices: set[int] = set()
 
         while True:
             fresh_data = await self._game_client.get_state()
@@ -888,10 +949,17 @@ class TwitchBot(commands.Bot):
                 logger.info("Rewards: state moved to '%s' — done", state.state_type)
                 return
 
-            auto_item = next((i for i in state.rewards_items if i.get("type") not in _VOTE_TYPES), None)
-            vote_item = next((i for i in state.rewards_items if i.get("type") in _VOTE_TYPES), None)
+            available = [i for i in state.rewards_items if i.get("index") not in skipped_indices]
+            auto_item = next((i for i in available if i.get("type") not in _VOTE_TYPES), None)
+            vote_item = next((i for i in available if i.get("type") in _VOTE_TYPES), None)
 
             if auto_item:
+                if auto_item.get("type") == "potion" and len(state.player_potions) >= self._max_belt_size:
+                    winner = await self._handle_belt_full_potion_discard(state, auto_item)
+                    if winner == "skip":
+                        skipped_indices.add(auto_item["index"])
+                    continue
+
                 await asyncio.sleep(self._auto_proceed_delay)
                 result = await self._game_client.post_action({"action": "claim_reward", "index": auto_item["index"]})
                 logger.info("Auto-claimed %s reward → %s", auto_item.get("type"), result)

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -119,8 +119,10 @@ class VoteManager:
         terminal actions like "end", "skip", "cancel" are never chosen without an explicit vote.
         Falls back to the full options list only if there are no numeric options at all.
         """
+        _terminal = frozenset({"end", "skip", "cancel"})
         numeric_options = [o for o in options if o.isdigit()]
-        random_pool = numeric_options if numeric_options else options
+        non_terminal = [o for o in options if o not in _terminal]
+        random_pool = numeric_options if numeric_options else (non_terminal if non_terminal else options)
 
         if not self._votes:
             winner = random.choice(random_pool)


### PR DESCRIPTION
## Summary
- When a potion reward appears on the rewards screen and the belt is full, opens a `!dN` / `!skip` chat vote instead of attempting a silent auto-claim. A discard win executes `discard_potion` then `claim_reward`; a skip win tracks the index so the rewards loop continues to remaining items.
- Fixes `_tally` bug: terminal options (`skip`, `end`, `cancel`) are now excluded from the random fallback pool when no numeric options exist — `!skip` can never be randomly chosen.
- Adds a 3-attempt / 0.5s retry in `_handle_vote_needed` when event state arrives with empty options (API timing on room transition), preventing fallback to static `!1 !2 !3`.
- Sends the game-started message as a purple Twitch announcement with a plain-chat fallback.

## Test plan
- [ ] Live test tracked in #71 (belt-full scenario is rare to set up)
- [ ] 165 unit tests pass (`python -m pytest`) ✅
- [ ] Event vote retry confirmed working in live session ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)