### PR TITLE
feat(#63): auto-navigate post-run screens back to main menu

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,6 +4,7 @@
 `PoC`
 
 ## Recently Completed
+- #63 — End-game nav: combat→overlay detection, `_handle_game_ended`, return_to_main_menu, timeline epoch claiming, 30s countdown; live-tested win + loss + epoch unlock
 - #53 — Belt-full potion reward: discard-to-claim vote (`_handle_belt_full_potion_discard`); skip tracking in rewards loop; `_tally` fix (skip never random); event vote retry fix; game-started as announcement
 - #60 — DRY chat-send: `_chat()` helper, `self.broadcaster` cached once, all send sites unified; live-tested
 - #59 — All 7 hardcoded timings/retries promoted to settings.yaml; threaded through loader, clients, polling, options, bot
@@ -14,10 +15,9 @@ None
 
 ## Up Next
 1. #71 — Live test: belt-full potion discard-to-claim + session untested changes
-2. #63 — End-game screen navigation (victory, defeat, unlocks)
-3. #7 — Database Logging
-4. #61 — Bundled minor code-hygiene cleanups
-5. #68 — Streaming setup & run logistics: OBS config, STS2 mod wiring, launch checklist
+2. #7 — Database Logging
+3. #61 — Bundled minor code-hygiene cleanups
+4. #68 — Streaming setup & run logistics: OBS config, STS2 mod wiring, launch checklist
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)

--- a/bot/client.py
+++ b/bot/client.py
@@ -291,6 +291,9 @@ class TwitchBot(commands.Bot):
         self._rest_site_poll_attempts: int = game_cfg.get("rest_site_poll_attempts", 10)
         self._rest_site_poll_interval: float = game_cfg.get("rest_site_poll_interval_seconds", 1.0)
         self._action_retry_count: int = game_cfg.get("action_retry_count", 1)
+        self._end_game_screen_pause: float = game_cfg.get("end_game_screen_pause_seconds", 5.0)
+        self._new_game_countdown: float = game_cfg.get("new_game_countdown_seconds", 30.0)
+        self._timeline_epoch_claim_delay: float = game_cfg.get("timeline_epoch_claim_delay_seconds", 5.0)
         self._max_belt_size: int = config.get("potions", {}).get("max_belt_size", 3)
         self._menu_initial_retry_attempts: int = menu_cfg.get("initial_query_retry_attempts", 5)
         self._menu_initial_retry_interval: float = menu_cfg.get("initial_query_retry_interval_seconds", 1.0)
@@ -371,8 +374,7 @@ class TwitchBot(commands.Bot):
                         )
                         await self._chat("A new run has started! Type !<choice> to vote when prompted.")
                 elif isinstance(event, GameEndedEvent):
-                    logger.info("Game ended: %s", event.state.summary())
-                    await self._chat("Run over! Thanks for playing.")
+                    await self._handle_game_ended(event)
                 elif isinstance(event, MenuSelectNeededEvent):
                     await self._handle_menu_select(broadcaster)
                 elif isinstance(event, VoteNeededEvent) and event.state.state_type == "rewards":
@@ -976,6 +978,90 @@ class TwitchBot(commands.Bot):
             logger.info("Auto-proceeded from rewards → %s", result)
             return
 
+    async def _handle_game_ended(self, event: GameEndedEvent) -> None:
+        """Send end-of-run announcement, navigate post-run screens back to menu, then announce countdown."""
+        logger.info("Game ended: %s", event.state.summary())
+        await self._chat("Run over! Thanks for playing.")
+
+        # Navigate defeat/victory/unlock screens back to menu.
+        # STS2MCP has no action for overlay/game-over screens; MenuControl handles them.
+        for attempt in range(20):  # cap at 20 attempts to avoid an infinite loop
+            await asyncio.sleep(self._end_game_screen_pause)
+            raw = await self._game_client.get_state()
+            if raw is None:
+                logger.warning("Post-run navigator: lost connection to game API — stopping")
+                return
+            state = GameState.from_api_response(raw)
+            if state.state_type == "menu":
+                logger.info("Post-run navigator: reached menu after %d attempt(s)", attempt)
+                menu_data = await self._menu_client.get_menu_state()
+                screen = (menu_data or {}).get("screen", "UNKNOWN")
+                available = (menu_data or {}).get("available_actions", [])
+                if screen == "TIMELINE":
+                    logger.info("Post-run navigator: timeline pending after return to menu — navigating")
+                    await self._navigate_timeline_screen(menu_data or {})
+                elif "open_timeline" in available:
+                    logger.info("Post-run navigator: opening timeline from main menu to claim pending epochs")
+                    await self._menu_client.post_menu_action("open_timeline")
+                    timeline_data = await self._menu_client.get_menu_state()
+                    await self._navigate_main_menu_timeline(timeline_data or {})
+                break
+            menu_data = await self._menu_client.get_menu_state()
+            screen = (menu_data or {}).get("screen", "UNKNOWN")
+            overlay_data = raw.get("overlay") or {}
+            logger.info(
+                "Post-run navigator: state_type=%r menu_screen=%r overlay=%r (attempt %d)",
+                state.state_type,
+                screen,
+                overlay_data,
+                attempt + 1,
+            )
+            if screen == "TIMELINE":
+                await self._navigate_timeline_screen(menu_data or {})
+            elif screen == "GAME_OVER":
+                await self._menu_client.post_menu_action("return_to_main_menu")
+            else:
+                logger.info("Post-run navigator: waiting on screen=%r", screen)
+        else:
+            logger.warning("Post-run navigator: did not reach menu after 20 attempts — giving up")
+            return
+
+        countdown = int(self._new_game_countdown)
+        await self._chat(f"New game starting in {countdown}s — get ready to vote!")
+        await asyncio.sleep(self._new_game_countdown)
+        # MenuSelectNeededEvent was queued by polling when state hit 'menu'; it runs next in the event runner.
+
+    async def _navigate_timeline_screen(self, menu_data: dict) -> None:
+        """Click through each epoch on the timeline unlock screen, then confirm."""
+        epochs = menu_data.get("epochs", [])
+        logger.info("Post-run navigator: timeline — %d epoch(s) to process", len(epochs))
+        for epoch in epochs:
+            idx = epoch["index"]
+            logger.info(
+                "Post-run navigator: clicking epoch %d (state=%r)", idx, epoch.get("state")
+            )
+            await self._menu_client.post_menu_action("choose_timeline_epoch", option_index=idx)
+            await asyncio.sleep(self._timeline_epoch_claim_delay)
+            # Close the per-epoch inspect overlay that opens after clicking
+            await self._menu_client.post_menu_action("confirm_timeline_overlay")
+            await asyncio.sleep(self._timeline_epoch_claim_delay)
+        # Final confirm for the unlock confirmation button that appears after all epochs are viewed
+        logger.info("Post-run navigator: final confirm_timeline_overlay")
+        await self._menu_client.post_menu_action("confirm_timeline_overlay")
+
+    async def _navigate_main_menu_timeline(self, menu_data: dict) -> None:
+        """Claim all Obtained epochs from the main menu timeline, then close."""
+        epochs = menu_data.get("epochs", [])
+        obtained = [e for e in epochs if e.get("state") != "Complete"]
+        logger.info("Main menu timeline: %d epoch(s) to claim (states: %s)", len(obtained), [e.get("state") for e in obtained])
+        for epoch in obtained:
+            idx = epoch["index"]
+            logger.info("Main menu timeline: claiming epoch %d", idx)
+            await self._menu_client.post_menu_action("choose_timeline_epoch", option_index=idx)
+            await asyncio.sleep(self._timeline_epoch_claim_delay)
+        await self._menu_client.post_menu_action("close_main_menu_submenu")
+        logger.info("Main menu timeline: closed, returning to main menu")
+
     async def _handle_menu_select(self, broadcaster: twitchio.PartialUser) -> None:
         """Handle a MenuSelectNeededEvent: navigate to character select, run vote, embark."""
         # Retry initial query — MenuControl may still be initializing when STS2MCP first reports menu
@@ -991,6 +1077,13 @@ class TwitchBot(commands.Bot):
 
         screen = menu_data.get("screen", "UNKNOWN")
         available_actions = menu_data.get("available_actions", [])
+
+        if screen == "TIMELINE":
+            logger.info("MenuControl: timeline pending at startup — navigating before character select")
+            await self._navigate_main_menu_timeline(menu_data)
+            menu_data = await self._menu_client.get_menu_state() or {}
+            screen = menu_data.get("screen", "UNKNOWN")
+            available_actions = menu_data.get("available_actions", [])
 
         if screen == "MAIN_MENU":
             if "open_character_select" not in available_actions:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -18,6 +18,9 @@ game:
   mid_turn_recheck_attempts: 5       # Extra polls after a card play / potion to catch immediate state changes
   mid_turn_recheck_interval_seconds: 0.5
   action_retry_count: 1              # How many times to retry a failed action POST
+  end_game_screen_pause_seconds: 5   # Pause on each post-run screen (you are slain, report) before proceeding
+  new_game_countdown_seconds: 30     # Wait after returning to menu before starting the next-run character vote
+  timeline_epoch_claim_delay_seconds: 5  # Pause between timeline epoch claims so viewers can read rewards
 
 api:
   sts2mcp_base_url: ""     # Required — set STS2MCP_BASE_URL in .env

--- a/game/polling.py
+++ b/game/polling.py
@@ -92,6 +92,10 @@ async def poll_game_state(
                         event_queue.put_nowait(GameStartedEvent(state))
                     elif state.state_type == "game_over":
                         event_queue.put_nowait(GameEndedEvent(state))
+                    elif previous_state.is_combat_state() and state.state_type == "overlay":
+                        # Player died — defeat screen appears as overlay before/instead of game_over
+                        logger.info("Combat ended in overlay — treating as game ended")
+                        event_queue.put_nowait(GameEndedEvent(state))
                     elif state.state_type == "menu":
                         logger.info("Game is at main menu — queuing character select vote")
                         event_queue.put_nowait(MenuSelectNeededEvent())
@@ -171,6 +175,9 @@ async def poll_game_state(
                                 )
                                 if recheck_state.requires_player_input():
                                     event_queue.put_nowait(VoteNeededEvent(recheck_state))
+                                elif state.is_combat_state() and recheck_state.state_type == "overlay":
+                                    logger.info("Combat ended in overlay after card play — treating as game ended")
+                                    event_queue.put_nowait(GameEndedEvent(recheck_state))
                             else:
                                 logger.info(
                                     "Mid-turn change (hand %s → %s, potions %d → %d) — re-queuing vote",

--- a/tests/bot/test_handle_game_ended.py
+++ b/tests/bot/test_handle_game_ended.py
@@ -1,0 +1,428 @@
+"""Tests for TwitchBot._handle_game_ended, _navigate_timeline_screen, and _navigate_main_menu_timeline."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bot.client import TwitchBot
+from game.events import GameEndedEvent
+from game.state import GameState
+
+
+def _api_response(state_type: str) -> dict:
+    return {"state_type": state_type}
+
+
+def _menu_state(
+    screen: str = "GAME_OVER",
+    epochs: list | None = None,
+    available_actions: list | None = None,
+) -> dict:
+    data: dict = {"screen": screen, "available_actions": available_actions or []}
+    if epochs is not None:
+        data["epochs"] = epochs
+    return data
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Patch asyncio.sleep in bot.client so tests never actually sleep."""
+    monkeypatch.setattr("bot.client.asyncio.sleep", AsyncMock())
+
+
+def _make_bot_self(
+    get_state_responses: list,
+    get_menu_state_responses: list | None = None,
+    new_game_countdown: float = 0.0,
+) -> MagicMock:
+    """Build a mock TwitchBot instance for _handle_game_ended tests.
+
+    get_menu_state call counts per loop iteration:
+      - Non-GAME_OVER / non-TIMELINE screens: 1 call
+      - GAME_OVER screen: 1 call (then return_to_main_menu via menu_client)
+      - TIMELINE screen: 1 call (then _navigate_timeline_screen)
+      - Post-break (menu reached): 1 call (+ 1 more if open_timeline is called)
+
+    If get_menu_state_responses is None, return_value=GAME_OVER is used (never exhausts).
+    """
+    bot = MagicMock(spec=TwitchBot)
+    bot._end_game_screen_pause = 0.0
+    bot._new_game_countdown = new_game_countdown
+    bot._timeline_epoch_claim_delay = 0.0
+
+    bot._chat = AsyncMock()
+
+    bot._game_client = MagicMock()
+    bot._game_client.get_state = AsyncMock(side_effect=get_state_responses)
+    bot._game_client.post_action = AsyncMock(return_value={"status": "ok"})
+
+    bot._menu_client = MagicMock()
+    if get_menu_state_responses is not None:
+        bot._menu_client.get_menu_state = AsyncMock(side_effect=get_menu_state_responses)
+    else:
+        bot._menu_client.get_menu_state = AsyncMock(return_value=_menu_state("GAME_OVER"))
+    bot._menu_client.post_menu_action = AsyncMock(return_value={"status": "ok"})
+
+    # Wire _navigate_timeline_screen and _navigate_main_menu_timeline to the real
+    # implementations so integration tests exercise the actual action sequences.
+    async def _real_navigate_timeline(menu_data: dict) -> None:
+        await TwitchBot._navigate_timeline_screen(bot, menu_data)
+
+    async def _real_navigate_main_menu_timeline(menu_data: dict) -> None:
+        await TwitchBot._navigate_main_menu_timeline(bot, menu_data)
+
+    bot._navigate_timeline_screen = _real_navigate_timeline
+    bot._navigate_main_menu_timeline = _real_navigate_main_menu_timeline
+
+    return bot
+
+
+def _game_ended_event() -> GameEndedEvent:
+    state = GameState(state_type="overlay", act=1, floor=5, player_hp=0, player_max_hp=70)
+    return GameEndedEvent(state=state)
+
+
+# ---------------------------------------------------------------------------
+# _handle_game_ended — basic navigation
+# ---------------------------------------------------------------------------
+
+async def test_game_over_screen_calls_return_to_main_menu():
+    """GAME_OVER screen → return_to_main_menu via MenuControl to exit the death screen."""
+    # Call sequence: 1 initial get_menu_state (GAME_OVER) + 1 post-break (MAIN_MENU)
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("overlay"), _api_response("menu")],
+        get_menu_state_responses=[_menu_state("GAME_OVER"), _menu_state("MAIN_MENU")],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    return_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "return_to_main_menu"
+    ]
+    assert len(return_calls) == 1
+    bot._game_client.post_action.assert_not_called()
+
+
+async def test_menu_immediately_skips_navigation():
+    """If STS2MCP already reports menu, no actions are posted."""
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("menu")],
+        get_menu_state_responses=[_menu_state("MAIN_MENU")],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    bot._game_client.post_action.assert_not_called()
+    bot._menu_client.post_menu_action.assert_not_called()
+
+
+async def test_chat_messages_sent():
+    """Both 'Run over' and 'New game starting' announcements are made."""
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("menu")],
+        get_menu_state_responses=[_menu_state("MAIN_MENU")],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert any("Run over" in t for t in texts)
+    assert any("New game starting" in t for t in texts)
+
+
+async def test_countdown_value_in_announcement():
+    """Countdown seconds come from _new_game_countdown, not hardcoded."""
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("menu")],
+        get_menu_state_responses=[_menu_state("MAIN_MENU")],
+        new_game_countdown=42.0,
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert any("42s" in t for t in texts)
+
+
+async def test_game_api_down_exits_without_countdown():
+    """If get_state returns None, exit cleanly — no countdown announcement."""
+    bot = _make_bot_self(get_state_responses=[None])
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert not any("New game" in t for t in texts)
+
+
+async def test_max_attempts_exceeded_exits_without_countdown():
+    """If menu is never reached after 20 attempts, give up — no countdown."""
+    # Default return_value=GAME_OVER never exhausts across 20 iterations
+    bot = _make_bot_self(get_state_responses=[_api_response("overlay")] * 25)
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert not any("New game" in t for t in texts)
+    return_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "return_to_main_menu"
+    ]
+    assert len(return_calls) == 20
+
+
+async def test_unknown_menu_screen_waits_without_action():
+    """An unexpected MenuControl screen takes no action that iteration."""
+    # Call sequence:
+    #   Iter 1 (overlay): IN_GAME → no action
+    #   Iter 2 (overlay): GAME_OVER → return_to_main_menu
+    #   Post-break (menu): MAIN_MENU
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("overlay"), _api_response("overlay"), _api_response("menu")],
+        get_menu_state_responses=[
+            _menu_state("IN_GAME"),
+            _menu_state("GAME_OVER"),
+            _menu_state("MAIN_MENU"),
+        ],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    return_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "return_to_main_menu"
+    ]
+    assert len(return_calls) == 1  # only the GAME_OVER iteration, not IN_GAME
+
+
+# ---------------------------------------------------------------------------
+# _handle_game_ended — timeline path (post-game overlay)
+# ---------------------------------------------------------------------------
+
+async def test_timeline_in_main_loop_is_navigated():
+    """TIMELINE in the main loop (state never changes to menu mid-loop) is navigated."""
+    # Call sequence: TIMELINE → navigate, then menu → post-break: MAIN_MENU
+    two_epochs = [{"index": 0, "state": "NotObtained"}, {"index": 1, "state": "NotObtained"}]
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("overlay"), _api_response("menu")],
+        get_menu_state_responses=[
+            _menu_state("TIMELINE", epochs=two_epochs),
+            _menu_state("MAIN_MENU"),
+        ],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert "choose_timeline_epoch" in actions
+    assert "confirm_timeline_overlay" in actions
+    bot._game_client.post_action.assert_not_called()
+
+
+async def test_timeline_detected_at_post_break_check():
+    """TIMELINE pending when STS2MCP first reports menu is caught by the post-break check."""
+    # Call sequence:
+    #   Iter 1 (overlay): GAME_OVER → return_to_main_menu
+    #   Post-break (menu): TIMELINE → navigate
+    one_epoch = [{"index": 0, "state": "NotObtained"}]
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("overlay"), _api_response("menu")],
+        get_menu_state_responses=[
+            _menu_state("GAME_OVER"),
+            _menu_state("TIMELINE", epochs=one_epoch),
+        ],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert "choose_timeline_epoch" in actions
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert any("New game starting" in t for t in texts)
+
+
+async def test_full_flow_death_report_timeline_countdown():
+    """Full post-run flow: GAME_OVER × 2 → TIMELINE → menu → countdown."""
+    one_epoch = [{"index": 0, "state": "NotObtained"}]
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("overlay"), _api_response("overlay"), _api_response("menu")],
+        get_menu_state_responses=[
+            _menu_state("GAME_OVER"),   # death screen → return_to_main_menu
+            _menu_state("GAME_OVER"),   # post-game report → return_to_main_menu
+            _menu_state("TIMELINE", epochs=one_epoch),  # post-break: timeline
+        ],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    return_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "return_to_main_menu"
+    ]
+    assert len(return_calls) == 2
+
+    timeline_actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert "choose_timeline_epoch" in timeline_actions
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert any("New game starting" in t for t in texts)
+
+
+# ---------------------------------------------------------------------------
+# _handle_game_ended — main menu timeline path
+# ---------------------------------------------------------------------------
+
+async def test_main_menu_open_timeline_claims_obtained_epochs():
+    """MAIN_MENU with open_timeline available → open timeline, claim Obtained epochs, close."""
+    # Call sequence:
+    #   Iter 1 (overlay): GAME_OVER → return_to_main_menu
+    #   Post-break (menu): MAIN_MENU with open_timeline → open_timeline call
+    #   After open_timeline: TIMELINE with one Obtained epoch
+    one_epoch = [{"index": 2, "state": "Obtained"}]
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("overlay"), _api_response("menu")],
+        get_menu_state_responses=[
+            _menu_state("GAME_OVER"),
+            _menu_state("MAIN_MENU", available_actions=["open_timeline"]),
+            _menu_state("TIMELINE", epochs=one_epoch),
+        ],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert "open_timeline" in actions
+    assert "choose_timeline_epoch" in actions
+    assert "close_main_menu_submenu" in actions
+
+
+async def test_main_menu_no_open_timeline_skips_timeline():
+    """MAIN_MENU without open_timeline in available_actions skips timeline navigation."""
+    bot = _make_bot_self(
+        get_state_responses=[_api_response("menu")],
+        get_menu_state_responses=[_menu_state("MAIN_MENU")],
+    )
+    await TwitchBot._handle_game_ended(bot, _game_ended_event())
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert "open_timeline" not in actions
+    assert "close_main_menu_submenu" not in actions
+
+
+# ---------------------------------------------------------------------------
+# _navigate_timeline_screen — unit tests (post-game overlay path)
+# ---------------------------------------------------------------------------
+
+def _make_bot_for_timeline() -> MagicMock:
+    bot = MagicMock(spec=TwitchBot)
+    bot._timeline_epoch_claim_delay = 0.0
+    bot._menu_client = MagicMock()
+    bot._menu_client.post_menu_action = AsyncMock(return_value={"status": "ok"})
+    return bot
+
+
+async def test_navigate_timeline_clicks_each_epoch():
+    """Each epoch gets a choose_timeline_epoch call with the correct index."""
+    epochs = [
+        {"index": 0, "state": "NotObtained"},
+        {"index": 1, "state": "NotObtained"},
+        {"index": 2, "state": "Obtained"},
+    ]
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_timeline_screen(bot, {"epochs": epochs})
+
+    choose_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "choose_timeline_epoch"
+    ]
+    assert len(choose_calls) == 3
+    indices = [c.kwargs["option_index"] for c in choose_calls]
+    assert indices == [0, 1, 2]
+
+
+async def test_navigate_timeline_confirms_after_each_epoch():
+    """confirm_timeline_overlay is called after each epoch and once more at the end."""
+    epochs = [{"index": 0, "state": "NotObtained"}, {"index": 1, "state": "NotObtained"}]
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_timeline_screen(bot, {"epochs": epochs})
+
+    confirm_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "confirm_timeline_overlay"
+    ]
+    assert len(confirm_calls) == len(epochs) + 1
+
+
+async def test_navigate_timeline_empty_epochs_only_final_confirm():
+    """With no epochs, only the final confirm_timeline_overlay is sent."""
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_timeline_screen(bot, {"epochs": []})
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert actions == ["confirm_timeline_overlay"]
+
+
+async def test_navigate_timeline_no_epochs_key():
+    """Missing 'epochs' key is treated as empty — only final confirm sent."""
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_timeline_screen(bot, {})
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert actions == ["confirm_timeline_overlay"]
+
+
+# ---------------------------------------------------------------------------
+# _navigate_main_menu_timeline — unit tests (main menu path)
+# ---------------------------------------------------------------------------
+
+async def test_navigate_main_menu_timeline_claims_obtained_epochs():
+    """Obtained epochs are claimed; close_main_menu_submenu is called at the end."""
+    epochs = [
+        {"index": 0, "state": "Complete"},
+        {"index": 1, "state": "Obtained"},
+        {"index": 2, "state": "Complete"},
+    ]
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_main_menu_timeline(bot, {"epochs": epochs})
+
+    choose_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "choose_timeline_epoch"
+    ]
+    assert len(choose_calls) == 1
+    assert choose_calls[0].kwargs["option_index"] == 1
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert "close_main_menu_submenu" in actions
+
+
+async def test_navigate_main_menu_timeline_skips_complete_epochs():
+    """Complete epochs are not clicked."""
+    epochs = [{"index": 0, "state": "Complete"}, {"index": 1, "state": "Complete"}]
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_main_menu_timeline(bot, {"epochs": epochs})
+
+    choose_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "choose_timeline_epoch"
+    ]
+    assert len(choose_calls) == 0
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert actions == ["close_main_menu_submenu"]
+
+
+async def test_navigate_main_menu_timeline_empty_epochs_closes_submenu():
+    """With no epochs, only close_main_menu_submenu is sent."""
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_main_menu_timeline(bot, {"epochs": []})
+
+    actions = [c.args[0] for c in bot._menu_client.post_menu_action.call_args_list]
+    assert actions == ["close_main_menu_submenu"]
+
+
+async def test_navigate_main_menu_timeline_multiple_obtained_all_claimed():
+    """Multiple Obtained epochs are all claimed in index order."""
+    epochs = [
+        {"index": 0, "state": "Obtained"},
+        {"index": 1, "state": "Complete"},
+        {"index": 2, "state": "Obtained"},
+    ]
+    bot = _make_bot_for_timeline()
+    await TwitchBot._navigate_main_menu_timeline(bot, {"epochs": epochs})
+
+    choose_calls = [
+        c for c in bot._menu_client.post_menu_action.call_args_list
+        if c.args[0] == "choose_timeline_epoch"
+    ]
+    assert len(choose_calls) == 2
+    assert [c.kwargs["option_index"] for c in choose_calls] == [0, 2]

--- a/tests/game/test_polling.py
+++ b/tests/game/test_polling.py
@@ -78,6 +78,14 @@ async def test_transition_to_game_over_emits_game_ended():
     assert any(isinstance(e, GameEndedEvent) for e in events)
 
 
+async def test_transition_combat_to_overlay_emits_game_ended():
+    """Player death often manifests as combat → overlay, not combat → game_over."""
+    q: asyncio.Queue = asyncio.Queue()
+    client = _make_client([_api_response("monster"), _api_response("overlay")])
+    events = await _drain(client, q)
+    assert any(isinstance(e, GameEndedEvent) for e in events)
+
+
 async def test_transition_to_new_actionable_state_emits_vote_needed():
     q: asyncio.Queue = asyncio.Queue()
     client = _make_client([_api_response("monster"), _api_response("card_reward")])
@@ -144,3 +152,17 @@ async def test_combat_new_round_detected_by_battle_round_increment():
     events = await _drain(client, q)
     vote_events = [e for e in events if isinstance(e, VoteNeededEvent)]
     assert len(vote_events) >= 2  # initial + new round
+
+
+async def test_combat_to_overlay_during_mid_turn_recheck_emits_game_ended():
+    """Death detected via mid-turn recheck path (card played → recheck → overlay)."""
+    q: asyncio.Queue = asyncio.Queue()
+    # r1: initial monster state with 2 cards in hand
+    r1 = _api_response("monster", battle={"is_play_phase": True, "round": 1, "enemies": [], "hand": ["a", "b"]})
+    # r2: same state but hand shrunk → triggers mid-turn recheck loop
+    r2 = _api_response("monster", battle={"is_play_phase": True, "round": 1, "enemies": [], "hand": ["a"]})
+    # r3: overlay — player died; detected during recheck
+    r3 = _api_response("overlay")
+    client = _make_client([r1, r2, r3])
+    events = await _drain(client, q)
+    assert any(isinstance(e, GameEndedEvent) for e in events)


### PR DESCRIPTION
## Summary

- Detects player death via `combat → overlay` transition in the polling loop (both normal path and mid-turn recheck path), emitting `GameEndedEvent`
- Adds `_handle_game_ended`: pauses 5s on the death screen, calls `return_to_main_menu` via MenuControl, then opens the timeline to claim any pending epoch unlocks before announcing a configurable countdown
- Adds `_navigate_main_menu_timeline`: iterates all non-`Complete` epochs with `choose_timeline_epoch`, then closes with `close_main_menu_submenu`
- Adds `_navigate_timeline_screen`: handles the post-game overlay timeline path (choose + confirm per epoch)
- Handles `TIMELINE` screen gracefully at bot startup in `_handle_menu_select`
- Adds three new `settings.yaml` knobs: `end_game_screen_pause_seconds` (5), `new_game_countdown_seconds` (30), `timeline_epoch_claim_delay_seconds` (5)

## Test plan

- [x] 187 unit tests pass (`python3 -m pytest tests/ -q`)
- [x] Live test: defeat run with no pending epochs → bot announces "Run over", pauses, returns to menu, announces countdown, starts character select vote
- [x] Live test: defeat run with pending epoch unlock → bot claims epoch via `choose_timeline_epoch`, closes timeline, then announces countdown
- [ ] First-ever timeline intro (empty epochs, no API action available) requires manual streamer click — tracked in issue #73

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)