### PR TITLE
fix(#71): detect silent belt-full failure in rewards loop

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,13 +11,13 @@
 - #62 — 165-test suite: state/actions/options/labels/polling/api_client/vote_manager; runs via `python -m pytest`, no live deps
 - #77 — fake_merchant: Foul Potion allowed at shop/fake_merchant (no target vote; API auto-infers merchant); 191 tests
 - #76 — Remove max_belt_size config: deleted `potions:` from settings/loader, dropped belt-full pre-check in `_shop_item_available`, rewards now attempt-then-react; STS2MCP feature request filed ([#72](https://github.com/Gennadiyev/STS2MCP/issues/72)); live-tested shop with full belt; 191 tests
+- #71 — Belt-full live test: fixed infinite-retry bug (API returns ok on full belt); `attempted_potion_indices` detects silent failure; live-tested discard-to-claim and skip paths; 191 tests
 
 ## Active Issue
 None
 
 ## Up Next
-1. #71 — Live test: belt-full potion discard-to-claim + session untested changes (includes #76 rewards behavior)
-2. #75 — Pre-ship hardening & code cleanup (consolidated from #9 + #61)
+1. #75 — Pre-ship hardening & code cleanup (consolidated from #9 + #61)
 3. #54 — Potion edge cases: combat-only filter (Foul Potion at shop/fake_merchant now resolved in #77)
 
 ## Key Decisions

--- a/bot/client.py
+++ b/bot/client.py
@@ -938,6 +938,7 @@ class TwitchBot(commands.Bot):
         """Auto-claim gold/relic/potion rewards, open card rewards for a chat vote, then proceed."""
         _VOTE_TYPES = {"card", "special_card", "card_removal"}
         skipped_indices: set[int] = set()
+        attempted_potion_indices: set[int] = set()
 
         while True:
             fresh_data = await self._game_client.get_state()
@@ -958,14 +959,28 @@ class TwitchBot(commands.Bot):
             vote_item = next((i for i in available if i.get("type") in _VOTE_TYPES), None)
 
             if auto_item:
+                idx = auto_item["index"]
+                is_potion = auto_item.get("type") == "potion"
+
+                # Detect silent belt-full failure: API returned ok but reward still present
+                if is_potion and idx in attempted_potion_indices:
+                    logger.info("Rewards: potion claim returned ok but reward persists — belt is full, triggering discard vote")
+                    attempted_potion_indices.discard(idx)
+                    winner = await self._handle_belt_full_potion_discard(state, auto_item)
+                    if winner == "skip":
+                        skipped_indices.add(idx)
+                    continue
+
                 await asyncio.sleep(self._auto_proceed_delay)
-                result = await self._game_client.post_action({"action": "claim_reward", "index": auto_item["index"]})
-                if result is None and auto_item.get("type") == "potion":
+                result = await self._game_client.post_action({"action": "claim_reward", "index": idx})
+                if result is None and is_potion:
                     logger.info("Rewards: potion claim failed — belt may be full, triggering discard vote")
                     winner = await self._handle_belt_full_potion_discard(state, auto_item)
                     if winner == "skip":
-                        skipped_indices.add(auto_item["index"])
+                        skipped_indices.add(idx)
                     continue
+                if is_potion:
+                    attempted_potion_indices.add(idx)
                 logger.info("Auto-claimed %s reward → %s", auto_item.get("type"), result)
                 continue
 


### PR DESCRIPTION
## Summary
- Fixes infinite-retry bug: game API returns `ok` even when potion claim fails on a full belt, causing the rewards loop to retry forever
- Added `attempted_potion_indices` tracking — if a potion reward index is still present after a claim attempt, triggers the discard vote instead of retrying
- Keeps existing `result is None` path for when the API is eventually fixed to return a real error

## Test plan
- [x] Live-tested discard-to-claim path (`!d1`): potion discarded, Skill Potion claimed, remaining rewards continued
- [x] Live-tested skip path (`!skip`): potion reward skipped, remaining rewards continued
- [x] 191 unit tests pass

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)