### PR TITLE
feat(#75): pre-ship hardening & code cleanup

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,28 +4,25 @@
 `PoC`
 
 ## Recently Completed
-- #63 — End-game nav: combat→overlay detection, `_handle_game_ended`, return_to_main_menu, timeline epoch claiming, 30s countdown; live-tested win + loss + epoch unlock
-- #53 — Belt-full potion reward: discard-to-claim vote (`_handle_belt_full_potion_discard`); skip tracking in rewards loop; `_tally` fix (skip never random); event vote retry fix; game-started as announcement
-- #60 — DRY chat-send: `_chat()` helper, `self.broadcaster` cached once, all send sites unified; live-tested
-- #59 — All 7 hardcoded timings/retries promoted to settings.yaml; threaded through loader, clients, polling, options, bot
-- #62 — 165-test suite: state/actions/options/labels/polling/api_client/vote_manager; runs via `python -m pytest`, no live deps
 - #77 — fake_merchant: Foul Potion allowed at shop/fake_merchant (no target vote; API auto-infers merchant); 191 tests
-- #76 — Remove max_belt_size config: deleted `potions:` from settings/loader, dropped belt-full pre-check in `_shop_item_available`, rewards now attempt-then-react; STS2MCP feature request filed ([#72](https://github.com/Gennadiyev/STS2MCP/issues/72)); live-tested shop with full belt; 191 tests
-- #71 — Belt-full live test: fixed infinite-retry bug (API returns ok on full belt); `attempted_potion_indices` detects silent failure; live-tested discard-to-claim and skip paths; 191 tests
+- #76 — Remove max_belt_size config: deleted `potions:` from settings/loader, dropped belt-full pre-check in `shop_item_available`, rewards now attempt-then-react; live-tested shop with full belt; 191 tests
+- #71 — Belt-full live test: fixed infinite-retry bug; `attempted_potion_indices` detects silent failure; live-tested discard-to-claim and skip paths; 191 tests
+- #75 — Pre-ship hardening & code cleanup: all 11 Part B hygiene items + 5 additional findings fixed; httpx retry with exponential backoff (configurable); TwitchIO reconnect guard; 195 tests; closes #9 and #61
 
 ## Active Issue
 None
 
 ## Up Next
-1. #75 — Pre-ship hardening & code cleanup (consolidated from #9 + #61)
-3. #54 — Potion edge cases: combat-only filter (Foul Potion at shop/fake_merchant now resolved in #77)
+1. #54 — Potion edge cases: combat-only filter for non-AnyEnemy potions
+2. #44 — Feature: end the run via supermajority chat vote
+3. #36 — Viewer info commands: deck/pile/relics/status lookup
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)
 - All API URLs required via .env — no hardcoded defaults in committed files
 - Fail loud on missing config at startup
 - Logging at INFO level to terminal + `logs/bot.log` (truncated each run, gitignored)
-- Test suite: `python -m pytest` from project root; 191 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
+- Test suite: `python -m pytest` from project root; 195 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
 - STS2MCP API on `localhost:15526`; enemy `entity_id` lives at `battle.enemies[i].entity_id`

--- a/bot/client.py
+++ b/bot/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import re
+from collections.abc import Callable
 
 import twitchio
 from twitchio import eventsub
@@ -18,6 +19,7 @@ from game.state import GameState, IDLE_STATES
 logger = logging.getLogger(__name__)
 
 _WIKI_BASE = "https://slaythespire.wiki.gg/wiki/Slay_the_Spire_2:"
+_REWARD_VOTE_TYPES: frozenset[str] = frozenset({"card", "special_card", "card_removal"})
 
 
 def _chunk_card_list(
@@ -292,6 +294,7 @@ class TwitchBot(commands.Bot):
         self._rest_site_poll_interval: float = game_cfg.get("rest_site_poll_interval_seconds", 1.0)
         self._action_retry_count: int = game_cfg.get("action_retry_count", 1)
         self._end_game_screen_pause: float = game_cfg.get("end_game_screen_pause_seconds", 5.0)
+        self._end_game_screen_max_nav_attempts: int = game_cfg.get("end_game_screen_max_nav_attempts", 20)
         self._new_game_countdown: float = game_cfg.get("new_game_countdown_seconds", 30.0)
         self._timeline_epoch_claim_delay: float = game_cfg.get("timeline_epoch_claim_delay_seconds", 5.0)
         self._menu_initial_retry_attempts: int = menu_cfg.get("initial_query_retry_attempts", 5)
@@ -301,6 +304,7 @@ class TwitchBot(commands.Bot):
 
         self.broadcaster: twitchio.PartialUser | None = None
         self._ready = asyncio.Event()  # set in event_ready; gates _event_runner
+        self._connected_once = False   # guards against double-announce on TwitchIO reconnect
 
         super().__init__(
             client_id=config["twitch"]["client_id"],
@@ -334,12 +338,16 @@ class TwitchBot(commands.Bot):
         )
 
     async def event_ready(self) -> None:
-        logger.info("Connected to Twitch as %s", self.user)
         users = await self.fetch_users(ids=[self._owner_id])
         self.broadcaster = users[0]
-        message = "[DRY RUN] Bot is online — votes run but actions are NOT sent to the game." if self._game_client.dry_run else "Bot is online!"
-        await self._chat(message)
-        self._ready.set()
+        if not self._connected_once:
+            self._connected_once = True
+            logger.info("Connected to Twitch as %s", self.user)
+            message = "[DRY RUN] Bot is online — votes run but actions are NOT sent to the game." if self._game_client.dry_run else "Bot is online!"
+            await self._chat(message)
+            self._ready.set()
+        else:
+            logger.info("Reconnected to Twitch as %s", self.user)
 
     async def event_command_error(self, payload: commands.CommandErrorPayload) -> None:
         # !1, !end, !left, etc. are not registered commands — silence the noise.
@@ -377,7 +385,7 @@ class TwitchBot(commands.Bot):
                 elif isinstance(event, MenuSelectNeededEvent):
                     await self._handle_menu_select(broadcaster)
                 elif isinstance(event, VoteNeededEvent) and event.state.state_type == "rewards":
-                    await self._handle_rewards()
+                    await self._handle_rewards(broadcaster)
                 elif isinstance(event, VoteNeededEvent) and event.state.card_select_screen_type == "select":
                     await self._handle_card_remove_event(event, broadcaster)
                 elif isinstance(event, VoteNeededEvent) and event.state.card_select_screen_type == "upgrade":
@@ -484,43 +492,32 @@ class TwitchBot(commands.Bot):
 
         return False
 
-    async def _handle_card_remove_event(self, event: VoteNeededEvent, broadcaster: twitchio.PartialUser) -> None:
-        """Handle a card_select 'select' (shop card removal) event with fresh state."""
-        remove_data = await self._game_client.get_state()
-        if not remove_data:
-            logger.warning("Card remove: could not fetch fresh state — discarding")
+    async def _handle_deck_select_event(
+        self,
+        broadcaster: twitchio.PartialUser,
+        screen_type: str,
+        context: str,
+        handler: Callable[[twitchio.PartialUser, GameState], object],
+    ) -> None:
+        """Fetch fresh state and dispatch to a card_select handler if screen_type matches."""
+        state = await self._fetch_parsed_state()
+        if state is None:
+            logger.warning("%s: could not fetch fresh state — discarding", context)
             return
-        try:
-            remove_state = GameState.from_api_response(remove_data)
-        except ValueError:
-            logger.warning("Card remove: could not parse fresh state — discarding")
-            return
-        if remove_state.card_select_screen_type == "select":
-            await self._handle_card_remove(broadcaster, remove_state)
+        if state.card_select_screen_type == screen_type:
+            await handler(broadcaster, state)
         else:
             logger.warning(
-                "Card remove: state moved to '%s' before vote started — discarding",
-                remove_state.state_type,
+                "%s: state moved to '%s' before vote started — discarding",
+                context,
+                state.state_type,
             )
 
+    async def _handle_card_remove_event(self, event: VoteNeededEvent, broadcaster: twitchio.PartialUser) -> None:
+        await self._handle_deck_select_event(broadcaster, "select", "Card remove", self._handle_card_remove)
+
     async def _handle_smith_upgrade_event(self, event: VoteNeededEvent, broadcaster: twitchio.PartialUser) -> None:
-        """Handle a card_select 'upgrade' (smith upgrade) event with fresh state."""
-        smith_data = await self._game_client.get_state()
-        if not smith_data:
-            logger.warning("Smith upgrade: could not fetch fresh state — discarding")
-            return
-        try:
-            smith_state = GameState.from_api_response(smith_data)
-        except ValueError:
-            logger.warning("Smith upgrade: could not parse fresh state — discarding")
-            return
-        if smith_state.card_select_screen_type == "upgrade":
-            await self._handle_smith_upgrade(broadcaster, smith_state)
-        else:
-            logger.warning(
-                "Smith upgrade: state moved to '%s' before vote started — discarding",
-                smith_state.state_type,
-            )
+        await self._handle_deck_select_event(broadcaster, "upgrade", "Smith upgrade", self._handle_smith_upgrade)
 
     async def _handle_vote_needed(self, event: VoteNeededEvent, broadcaster: twitchio.PartialUser) -> None:
         """Handle a general VoteNeededEvent: stale-check, auto-proceed, vote, execute."""
@@ -626,7 +623,11 @@ class TwitchBot(commands.Bot):
         action = body.get("action", "")
 
         # shop/fake_merchant: re-queue vote after purchase or potion use
-        if action_state.state_type in ("shop", "fake_merchant") and action in ("shop_purchase", "use_potion") and result is not None:
+        if (
+            action_state.state_type in ("shop", "fake_merchant")
+            and action in ("shop_purchase", "use_potion")
+            and result is not None
+        ):
             post_state = await self._fetch_parsed_state()
             if post_state and post_state.state_type == action_state.state_type:
                 logger.info("Shop purchase complete — re-queuing vote")
@@ -638,7 +639,7 @@ class TwitchBot(commands.Bot):
             if post_state and post_state.requires_player_input():
                 self._event_queue.put_nowait(VoteNeededEvent(post_state))
 
-        # rest_site: after choosing an option, poll until can_proceed=True then decide
+        # State-specific follow-up (mutually exclusive — only one branch fires per call)
         if action_state.state_type == "rest_site" and action == "choose_rest_option":
             for _ in range(self._rest_site_poll_attempts):
                 await asyncio.sleep(self._rest_site_poll_interval)
@@ -666,41 +667,27 @@ class TwitchBot(commands.Bot):
 
         # hand_select: confirm when can_confirm=True, re-queue if more selections needed
         elif action_state.state_type == "hand_select" and action == "combat_select_card":
-            hs_data = await self._game_client.get_state()
-            if not hs_data:
+            hs_state = await self._fetch_parsed_state()
+            if hs_state is None or hs_state.state_type != "hand_select":
                 confirm_result = await self._game_client.post_action({"action": "combat_confirm_selection"})
                 logger.info("Auto-confirmed hand_select (no fresh state) → %s", confirm_result)
+            elif hs_state.hand_select_can_confirm:
+                confirm_result = await self._game_client.post_action({"action": "combat_confirm_selection"})
+                logger.info("Auto-confirmed hand_select → %s", confirm_result)
             else:
-                try:
-                    hs_state = GameState.from_api_response(hs_data)
-                except ValueError:
-                    confirm_result = await self._game_client.post_action({"action": "combat_confirm_selection"})
-                    logger.info("Auto-confirmed hand_select (state parse failed) → %s", confirm_result)
-                else:
-                    if hs_state.state_type == "hand_select":
-                        if hs_state.hand_select_can_confirm:
-                            confirm_result = await self._game_client.post_action({"action": "combat_confirm_selection"})
-                            logger.info("Auto-confirmed hand_select → %s", confirm_result)
-                        else:
-                            logger.info("hand_select: more selections needed — re-queuing vote")
-                            self._event_queue.put_nowait(VoteNeededEvent(hs_state))
+                logger.info("hand_select: more selections needed — re-queuing vote")
+                self._event_queue.put_nowait(VoteNeededEvent(hs_state))
 
         # card_select: re-queue if more selections needed, auto-confirm when ready
         elif action_state.state_type == "card_select" and action == "select_card":
-            cs_data = await self._game_client.get_state()
-            if cs_data:
-                try:
-                    cs_state = GameState.from_api_response(cs_data)
-                except ValueError:
-                    pass
+            cs_state = await self._fetch_parsed_state()
+            if cs_state and cs_state.state_type == "card_select":
+                if cs_state.card_select_can_confirm:
+                    confirm_result = await self._game_client.post_action({"action": "confirm_selection"})
+                    logger.info("Auto-confirmed card_select → %s", confirm_result)
                 else:
-                    if cs_state.state_type == "card_select":
-                        if cs_state.card_select_can_confirm:
-                            confirm_result = await self._game_client.post_action({"action": "confirm_selection"})
-                            logger.info("Auto-confirmed card_select → %s", confirm_result)
-                        else:
-                            logger.info("card_select: more selections needed — re-queuing vote")
-                            self._event_queue.put_nowait(VoteNeededEvent(cs_state))
+                    logger.info("card_select: more selections needed — re-queuing vote")
+                    self._event_queue.put_nowait(VoteNeededEvent(cs_state))
 
         # Dry-run: game state never changes so the poller never fires a new event.
         # Re-queue manually so testing can continue without restarting the bot.
@@ -743,15 +730,8 @@ class TwitchBot(commands.Bot):
         )
 
         # Guard: re-check enemy list after vote (theoretically impossible to change in SP)
-        guard_data = await self._game_client.get_state()
-        current_enemies = enemies
-        if guard_data:
-            try:
-                guard_state = GameState.from_api_response(guard_data)
-                if guard_state.enemies:
-                    current_enemies = guard_state.enemies
-            except ValueError:
-                pass
+        guard_state = await self._fetch_parsed_state()
+        current_enemies = guard_state.enemies if guard_state and guard_state.enemies else enemies
 
         if len(current_enemies) == 1:
             logger.info("Enemy list changed to 1 after target vote — auto-targeting %s", current_enemies[0]["name"])
@@ -850,22 +830,17 @@ class TwitchBot(commands.Bot):
         result = await self._game_client.post_action({"action": "select_card", "index": api_index})
         logger.info("Deck select (%s): '%s' (api_index=%d) → %s", state_summary, winner_label, api_index, result)
 
-        post_data = await self._game_client.get_state()
-        if post_data:
-            try:
-                post_state = GameState.from_api_response(post_data)
-            except ValueError:
-                post_state = None
-            if post_state is not None and post_state.state_type == "card_select":
-                if post_state.card_select_can_confirm:
-                    confirm_result = await self._game_client.post_action({"action": "confirm_selection"})
-                    logger.info("Deck select (%s): confirmed → %s", state_summary, confirm_result)
-                else:
-                    logger.warning(
-                        "Deck select (%s): still in card_select but can_confirm=False — "
-                        "selection may not be committed",
-                        state_summary,
-                    )
+        post_state = await self._fetch_parsed_state()
+        if post_state is not None and post_state.state_type == "card_select":
+            if post_state.card_select_can_confirm:
+                confirm_result = await self._game_client.post_action({"action": "confirm_selection"})
+                logger.info("Deck select (%s): confirmed → %s", state_summary, confirm_result)
+            else:
+                logger.warning(
+                    "Deck select (%s): still in card_select but can_confirm=False — "
+                    "selection may not be committed",
+                    state_summary,
+                )
 
     async def _handle_card_remove(
         self,
@@ -895,7 +870,12 @@ class TwitchBot(commands.Bot):
             duration=duration,
         )
 
-    async def _handle_belt_full_potion_discard(self, state: GameState, potion_item: dict) -> str:
+    async def _handle_belt_full_potion_discard(
+        self,
+        broadcaster: twitchio.PartialUser,
+        state: GameState,
+        potion_item: dict,
+    ) -> str:
         """Vote to discard a held potion to claim a belt-full potion reward, or skip it.
 
         Returns "skip" if chat skips, or the winning "dN" tag otherwise.
@@ -909,7 +889,7 @@ class TwitchBot(commands.Bot):
         preamble = f"Belt full! Discard a potion to claim {reward_name}, or !skip to pass."
 
         winner = await self.vote_manager.run_window(
-            broadcaster=self.broadcaster,
+            broadcaster=broadcaster,
             bot_id=self.bot_id,
             options=options,
             state_summary="rewards belt-full discard",
@@ -934,29 +914,23 @@ class TwitchBot(commands.Bot):
 
         return winner
 
-    async def _handle_rewards(self) -> None:
+    async def _handle_rewards(self, broadcaster: twitchio.PartialUser) -> None:
         """Auto-claim gold/relic/potion rewards, open card rewards for a chat vote, then proceed."""
-        _VOTE_TYPES = {"card", "special_card", "card_removal"}
         skipped_indices: set[int] = set()
         attempted_potion_indices: set[int] = set()
 
         while True:
-            fresh_data = await self._game_client.get_state()
-            if not fresh_data:
-                logger.warning("Rewards: could not fetch fresh state — skipping")
-                return
-            try:
-                state = GameState.from_api_response(fresh_data)
-            except ValueError:
-                logger.warning("Rewards: malformed state response — skipping")
+            state = await self._fetch_parsed_state()
+            if state is None:
+                logger.warning("Rewards: could not fetch or parse state — skipping")
                 return
             if state.state_type != "rewards":
                 logger.info("Rewards: state moved to '%s' — done", state.state_type)
                 return
 
             available = [i for i in state.rewards_items if i.get("index") not in skipped_indices]
-            auto_item = next((i for i in available if i.get("type") not in _VOTE_TYPES), None)
-            vote_item = next((i for i in available if i.get("type") in _VOTE_TYPES), None)
+            auto_item = next((i for i in available if i.get("type") not in _REWARD_VOTE_TYPES), None)
+            vote_item = next((i for i in available if i.get("type") in _REWARD_VOTE_TYPES), None)
 
             if auto_item:
                 idx = auto_item["index"]
@@ -966,7 +940,7 @@ class TwitchBot(commands.Bot):
                 if is_potion and idx in attempted_potion_indices:
                     logger.info("Rewards: potion claim returned ok but reward persists — belt is full, triggering discard vote")
                     attempted_potion_indices.discard(idx)
-                    winner = await self._handle_belt_full_potion_discard(state, auto_item)
+                    winner = await self._handle_belt_full_potion_discard(broadcaster, state, auto_item)
                     if winner == "skip":
                         skipped_indices.add(idx)
                     continue
@@ -975,7 +949,7 @@ class TwitchBot(commands.Bot):
                 result = await self._game_client.post_action({"action": "claim_reward", "index": idx})
                 if result is None and is_potion:
                     logger.info("Rewards: potion claim failed — belt may be full, triggering discard vote")
-                    winner = await self._handle_belt_full_potion_discard(state, auto_item)
+                    winner = await self._handle_belt_full_potion_discard(broadcaster, state, auto_item)
                     if winner == "skip":
                         skipped_indices.add(idx)
                     continue
@@ -1002,13 +976,17 @@ class TwitchBot(commands.Bot):
 
         # Navigate defeat/victory/unlock screens back to menu.
         # STS2MCP has no action for overlay/game-over screens; MenuControl handles them.
-        for attempt in range(20):  # cap at 20 attempts to avoid an infinite loop
+        for attempt in range(self._end_game_screen_max_nav_attempts):
             await asyncio.sleep(self._end_game_screen_pause)
             raw = await self._game_client.get_state()
             if raw is None:
                 logger.warning("Post-run navigator: lost connection to game API — stopping")
                 return
-            state = GameState.from_api_response(raw)
+            try:
+                state = GameState.from_api_response(raw)
+            except ValueError:
+                logger.error("Post-run navigator: failed to parse game state — stopping", exc_info=True)
+                return
             if state.state_type == "menu":
                 logger.info("Post-run navigator: reached menu after %d attempt(s)", attempt)
                 menu_data = await self._menu_client.get_menu_state()
@@ -1040,7 +1018,7 @@ class TwitchBot(commands.Bot):
             else:
                 logger.info("Post-run navigator: waiting on screen=%r", screen)
         else:
-            logger.warning("Post-run navigator: did not reach menu after 20 attempts — giving up")
+            logger.warning("Post-run navigator: did not reach menu after %d attempts — giving up", self._end_game_screen_max_nav_attempts)
             return
 
         countdown = int(self._new_game_countdown)

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -19,13 +19,16 @@ game:
   mid_turn_recheck_interval_seconds: 0.5
   action_retry_count: 1              # How many times to retry a failed action POST
   end_game_screen_pause_seconds: 5   # Pause on each post-run screen (you are slain, report) before proceeding
+  end_game_screen_max_nav_attempts: 20  # Max attempts to navigate post-run screens back to menu
   new_game_countdown_seconds: 30     # Wait after returning to menu before starting the next-run character vote
   timeline_epoch_claim_delay_seconds: 5  # Pause between timeline epoch claims so viewers can read rewards
 
 api:
   sts2mcp_base_url: ""     # Required — set STS2MCP_BASE_URL in .env
   sts2_menu_base_url: ""   # Required — set STS2_MENU_BASE_URL in .env
-  http_timeout_seconds: 5.0  # HTTP client timeout for all game/menu API calls
+  http_timeout_seconds: 5.0        # HTTP client timeout for all game/menu API calls
+  http_retry_attempts: 3           # Retries on transient failures (ConnectError/Timeout); 0 to disable
+  http_retry_backoff_seconds: 0.5  # Initial backoff between retries; doubles each attempt
 
 menu:
   initial_query_retry_attempts: 5     # Retries when MenuControl may still be initializing
@@ -37,6 +40,3 @@ logging:
   level: "INFO"             # Bot log level (DEBUG, INFO, WARNING, ERROR)
   twitchio_level: "WARNING" # Suppress verbose TwitchIO output
   httpx_level: "WARNING"    # Suppress verbose httpx output
-
-database:
-  path: "data/game_history.db"

--- a/game/actions.py
+++ b/game/actions.py
@@ -90,16 +90,7 @@ def build_api_body(state: GameState, winner: str, target_entity_id: str | None =
         except ValueError:
             pass
 
-    elif st == "shop":
-        if winner == "end":
-            return {"action": "proceed"}
-        try:
-            idx = int(winner) - 1
-            return {"action": "shop_purchase", "index": idx}
-        except ValueError:
-            pass
-
-    elif st == "fake_merchant":
+    elif st in ("shop", "fake_merchant"):
         if winner == "end":
             return {"action": "proceed"}
         try:
@@ -149,6 +140,9 @@ def build_api_body(state: GameState, winner: str, target_entity_id: str | None =
     elif st == "crystal_sphere":
         try:
             idx = int(winner) - 1
+        except ValueError:
+            pass
+        else:
             cells = state.crystal_sphere_cells
             if not cells:
                 raise ValueError("crystal_sphere_cells is empty — cannot resolve coordinates")
@@ -158,10 +152,6 @@ def build_api_body(state: GameState, winner: str, target_entity_id: str | None =
                 )
             cell = cells[idx]
             return {"action": "crystal_sphere_click_cell", "x": cell["x"], "y": cell["y"]}
-        except (ValueError, KeyError) as exc:
-            raise ValueError(
-                f"crystal_sphere action failed for winner={winner!r}: {exc}"
-            ) from exc
 
     raise ValueError(
         f"No API mapping for state_type={st!r}, winner={winner!r}. "

--- a/game/api_client.py
+++ b/game/api_client.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from collections.abc import Callable, Awaitable
 
 import httpx
 
@@ -6,25 +8,59 @@ logger = logging.getLogger(__name__)
 
 
 class STS2Client:
-    def __init__(self, base_url: str, dry_run: bool = False, http_timeout: float = 5.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        dry_run: bool = False,
+        http_timeout: float = 5.0,
+        http_retry_attempts: int = 3,
+        http_retry_backoff_seconds: float = 0.5,
+    ) -> None:
         self._base_url = base_url.rstrip("/")
         self._http = httpx.AsyncClient(timeout=http_timeout)
         self.dry_run = dry_run
+        self._http_retry_attempts = http_retry_attempts
+        self._http_retry_backoff_seconds = http_retry_backoff_seconds
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""
         await self._http.aclose()
 
+    async def _retry(
+        self,
+        label: str,
+        coro_factory: Callable[[], Awaitable[httpx.Response]],
+    ) -> httpx.Response | None:
+        """Execute coro_factory() with exponential backoff retry on transient failures.
+
+        Retries up to `http_retry_attempts` times on ConnectError or TimeoutException.
+        Returns None when all attempts are exhausted.
+        """
+        for attempt in range(self._http_retry_attempts + 1):
+            try:
+                return await coro_factory()
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                if attempt < self._http_retry_attempts:
+                    delay = self._http_retry_backoff_seconds * (2 ** attempt)
+                    logger.warning(
+                        "%s: transient error (%s) — retry %d/%d in %.1fs",
+                        label, type(exc).__name__, attempt + 1, self._http_retry_attempts, delay,
+                    )
+                    await asyncio.sleep(delay)
+        return None
+
     async def get_state(self) -> dict | None:
         """Fetch current game state from STS2MCP. Returns parsed JSON or None on failure."""
-        try:
-            response = await self._http.get(f"{self._base_url}/api/v1/singleplayer")
-            if response.is_success:
-                return response.json()
-            logger.warning("STS2MCP API returned status %s", response.status_code)
+        response = await self._retry(
+            "STS2MCP GET",
+            lambda: self._http.get(f"{self._base_url}/api/v1/singleplayer"),
+        )
+        if response is None:
             return None
-        except (httpx.ConnectError, httpx.TimeoutException):
-            return None
+        if response.is_success:
+            return response.json()
+        logger.warning("STS2MCP API returned status %s", response.status_code)
+        return None
 
     async def post_action(self, body: dict) -> dict | None:
         """Submit a player action to STS2MCP. Returns parsed JSON or None on failure.
@@ -35,17 +71,17 @@ class STS2Client:
         if self.dry_run:
             logger.info("[DRY RUN] Skipping action: %s", body)
             return {"status": "ok", "message": f"[DRY RUN] {body}"}
-        try:
-            response = await self._http.post(
-                f"{self._base_url}/api/v1/singleplayer", json=body
-            )
-            if response.is_success:
-                return response.json()
-            logger.warning(
-                "STS2MCP action POST returned status %s: %s",
-                response.status_code,
-                response.text,
-            )
+        response = await self._retry(
+            "STS2MCP POST",
+            lambda: self._http.post(f"{self._base_url}/api/v1/singleplayer", json=body),
+        )
+        if response is None:
             return None
-        except (httpx.ConnectError, httpx.TimeoutException):
-            return None
+        if response.is_success:
+            return response.json()
+        logger.warning(
+            "STS2MCP action POST returned status %s: %s",
+            response.status_code,
+            response.text,
+        )
+        return None

--- a/game/labels.py
+++ b/game/labels.py
@@ -1,6 +1,6 @@
 import logging
 
-from game.options import _shop_item_available, potion_vote_entries
+from game.options import shop_item_available, potion_vote_entries
 from game.state import GameState
 
 logger = logging.getLogger(__name__)
@@ -81,7 +81,7 @@ def _base_labels_for_state(state: GameState) -> dict[str, str]:
         }
 
     if state.state_type in ("shop", "fake_merchant") and state.shop_items:
-        stocked = [i for i in state.shop_items if _shop_item_available(i, state)]
+        stocked = [i for i in state.shop_items if shop_item_available(i, state)]
         def _shop_label(item: dict) -> str:
             category = item.get("category", "")
             # API uses flat prefixed fields: card_name, relic_name, potion_name

--- a/game/menu_client.py
+++ b/game/menu_client.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from collections.abc import Callable, Awaitable
 
 import httpx
 
@@ -6,24 +8,57 @@ logger = logging.getLogger(__name__)
 
 
 class MenuClient:
-    def __init__(self, base_url: str, http_timeout: float = 5.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        http_timeout: float = 5.0,
+        http_retry_attempts: int = 3,
+        http_retry_backoff_seconds: float = 0.5,
+    ) -> None:
         self._base_url = base_url.rstrip("/")
         self._http = httpx.AsyncClient(timeout=http_timeout)
+        self._http_retry_attempts = http_retry_attempts
+        self._http_retry_backoff_seconds = http_retry_backoff_seconds
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""
         await self._http.aclose()
 
+    async def _retry(
+        self,
+        label: str,
+        coro_factory: Callable[[], Awaitable[httpx.Response]],
+    ) -> httpx.Response | None:
+        """Execute coro_factory() with exponential backoff retry on transient failures.
+
+        Retries up to `http_retry_attempts` times on ConnectError or TimeoutException.
+        Returns None when all attempts are exhausted.
+        """
+        for attempt in range(self._http_retry_attempts + 1):
+            try:
+                return await coro_factory()
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                if attempt < self._http_retry_attempts:
+                    delay = self._http_retry_backoff_seconds * (2 ** attempt)
+                    logger.warning(
+                        "%s: transient error (%s) — retry %d/%d in %.1fs",
+                        label, type(exc).__name__, attempt + 1, self._http_retry_attempts, delay,
+                    )
+                    await asyncio.sleep(delay)
+        return None
+
     async def get_menu_state(self) -> dict | None:
         """Fetch current menu screen state from STS2-MenuControl. Returns parsed JSON or None on failure."""
-        try:
-            response = await self._http.get(f"{self._base_url}/api/v1/menu")
-            if response.is_success:
-                return response.json()
-            logger.warning("MenuControl API returned status %s", response.status_code)
+        response = await self._retry(
+            "MenuControl GET",
+            lambda: self._http.get(f"{self._base_url}/api/v1/menu"),
+        )
+        if response is None:
             return None
-        except (httpx.ConnectError, httpx.TimeoutException):
-            return None
+        if response.is_success:
+            return response.json()
+        logger.warning("MenuControl API returned status %s", response.status_code)
+        return None
 
     async def post_menu_action(
         self, action: str, option_index: int | None = None
@@ -32,17 +67,17 @@ class MenuClient:
         body: dict = {"action": action}
         if option_index is not None:
             body["option_index"] = option_index
-        try:
-            response = await self._http.post(
-                f"{self._base_url}/api/v1/menu", json=body
-            )
-            if response.is_success:
-                return response.json()
-            logger.warning(
-                "MenuControl action POST returned status %s: %s",
-                response.status_code,
-                response.text,
-            )
+        response = await self._retry(
+            "MenuControl POST",
+            lambda: self._http.post(f"{self._base_url}/api/v1/menu", json=body),
+        )
+        if response is None:
             return None
-        except (httpx.ConnectError, httpx.TimeoutException):
-            return None
+        if response.is_success:
+            return response.json()
+        logger.warning(
+            "MenuControl action POST returned status %s: %s",
+            response.status_code,
+            response.text,
+        )
+        return None

--- a/game/options.py
+++ b/game/options.py
@@ -106,7 +106,7 @@ def potion_vote_entries(state: GameState) -> tuple[list[tuple[str, str]], list[t
     return use_entries, discard_entries
 
 
-def _shop_item_available(item: dict, state: GameState) -> bool:
+def shop_item_available(item: dict, state: GameState) -> bool:
     """Return True if a shop item can be meaningfully purchased right now."""
     if not item.get("is_stocked", True):
         return False
@@ -153,7 +153,7 @@ def _base_options_for_state(state: GameState) -> list[str]:
 
     if state.state_type in ("shop", "fake_merchant"):
         # Only offer items that are stocked, affordable, and purchasable given current state
-        available = [i for i in state.shop_items if _shop_item_available(i, state)]
+        available = [i for i in state.shop_items if shop_item_available(i, state)]
         if available:
             return [str(i["index"] + 1) for i in available] + ["end"]
         return ["end"]  # no purchasable items — only option is to leave

--- a/game/polling.py
+++ b/game/polling.py
@@ -3,7 +3,8 @@ import logging
 
 from game.api_client import STS2Client
 from game.events import GameEndedEvent, GameStartedEvent, GameEvent, MenuSelectNeededEvent, VoteNeededEvent
-from game.state import GameState
+from game.options import KNOWN_STATES
+from game.state import GameState, IDLE_STATES
 
 logger = logging.getLogger(__name__)
 
@@ -22,21 +23,18 @@ def _log_within_state_changes(prev: GameState, curr: GameState) -> None:
     if curr.player_energy != prev.player_energy and curr.player_energy is not None:
         logger.info("Player energy: %s → %s", prev.player_energy, curr.player_energy)
 
-    for i, enemy in enumerate(curr.enemies):
-        if i >= len(prev.enemies):
-            break
-        prev_enemy = prev.enemies[i]
+    for prev_enemy, enemy in zip(prev.enemies, curr.enemies):
         if enemy.get("hp") != prev_enemy.get("hp"):
             logger.info(
                 "%s HP: %s → %s",
-                enemy.get("name", f"Enemy {i}"),
+                enemy.get("name", prev_enemy.get("name", "Enemy")),
                 prev_enemy.get("hp"),
                 enemy.get("hp"),
             )
         if enemy.get("block") != prev_enemy.get("block"):
             logger.info(
                 "%s block: %s → %s",
-                enemy.get("name", f"Enemy {i}"),
+                enemy.get("name", prev_enemy.get("name", "Enemy")),
                 prev_enemy.get("block"),
                 enemy.get("block"),
             )
@@ -66,12 +64,7 @@ async def poll_game_state(
                     logger.info("STS2MCP API reconnected")
                     api_reachable = True
                 state = GameState.from_api_response(data)
-                if state.state_type not in {
-                    "menu", "monster", "elite", "boss", "map", "event", "rest_site",
-                    "shop", "fake_merchant", "card_reward", "rewards", "treasure",
-                    "hand_select", "card_select", "bundle_select", "relic_select",
-                    "crystal_sphere", "game_over", "unknown", "overlay",
-                }:
+                if state.state_type not in KNOWN_STATES.keys() | IDLE_STATES:
                     logger.info("UNKNOWN STATE: type=%s keys=%s", state.state_type, list(data.keys()))
 
                 if previous_state is None:

--- a/main.py
+++ b/main.py
@@ -37,9 +37,23 @@ async def main() -> None:
     if dry_run:
         logger.warning("DRY RUN MODE — actions will be logged but NOT sent to the game API")
 
-    http_timeout = config["api"].get("http_timeout_seconds", 5.0)
-    game_client = STS2Client(config["api"]["sts2mcp_base_url"], dry_run=dry_run, http_timeout=http_timeout)
-    menu_client = MenuClient(config["api"]["sts2_menu_base_url"], http_timeout=http_timeout)
+    api_cfg = config["api"]
+    http_timeout = api_cfg.get("http_timeout_seconds", 5.0)
+    http_retry_attempts = api_cfg.get("http_retry_attempts", 3)
+    http_retry_backoff = api_cfg.get("http_retry_backoff_seconds", 0.5)
+    game_client = STS2Client(
+        api_cfg["sts2mcp_base_url"],
+        dry_run=dry_run,
+        http_timeout=http_timeout,
+        http_retry_attempts=http_retry_attempts,
+        http_retry_backoff_seconds=http_retry_backoff,
+    )
+    menu_client = MenuClient(
+        api_cfg["sts2_menu_base_url"],
+        http_timeout=http_timeout,
+        http_retry_attempts=http_retry_attempts,
+        http_retry_backoff_seconds=http_retry_backoff,
+    )
 
     state = await game_client.get_state()
     if state is not None:

--- a/tests/bot/test_handle_game_ended.py
+++ b/tests/bot/test_handle_game_ended.py
@@ -47,6 +47,7 @@ def _make_bot_self(
     """
     bot = MagicMock(spec=TwitchBot)
     bot._end_game_screen_pause = 0.0
+    bot._end_game_screen_max_nav_attempts = 20
     bot._new_game_countdown = new_game_countdown
     bot._timeline_epoch_claim_delay = 0.0
 

--- a/tests/game/test_api_client.py
+++ b/tests/game/test_api_client.py
@@ -10,7 +10,14 @@ ENDPOINT = f"{BASE_URL}/api/v1/singleplayer"
 
 @pytest.fixture
 def client() -> STS2Client:
-    return STS2Client(base_url=BASE_URL)
+    """No-retry client for straightforward success/error tests."""
+    return STS2Client(base_url=BASE_URL, http_retry_attempts=0)
+
+
+@pytest.fixture
+def retrying_client() -> STS2Client:
+    """Client with 2 retries and zero backoff for retry behaviour tests."""
+    return STS2Client(base_url=BASE_URL, http_retry_attempts=2, http_retry_backoff_seconds=0.0)
 
 
 # --- get_state ---
@@ -78,6 +85,48 @@ async def test_post_action_timeout_returns_none(client: STS2Client, httpx_mock: 
     httpx_mock.add_exception(httpx.TimeoutException("timed out"))
     result = await client.post_action({"action": "end_turn"})
     assert result is None
+
+
+# --- retry with exponential backoff ---
+
+async def test_get_state_retries_on_connect_error_then_succeeds(
+    retrying_client: STS2Client, httpx_mock: HTTPXMock
+):
+    """First attempt fails with ConnectError; second succeeds."""
+    httpx_mock.add_exception(httpx.ConnectError("refused"))
+    httpx_mock.add_response(url=ENDPOINT, json={"state_type": "menu"})
+    result = await retrying_client.get_state()
+    assert result == {"state_type": "menu"}
+
+
+async def test_get_state_exhausts_retries_returns_none(
+    retrying_client: STS2Client, httpx_mock: HTTPXMock
+):
+    """All 3 attempts (1 initial + 2 retries) raise ConnectError — should return None."""
+    for _ in range(3):
+        httpx_mock.add_exception(httpx.ConnectError("refused"))
+    result = await retrying_client.get_state()
+    assert result is None
+
+
+async def test_post_action_retries_on_timeout_then_succeeds(
+    retrying_client: STS2Client, httpx_mock: HTTPXMock
+):
+    """First attempt times out; second succeeds."""
+    httpx_mock.add_exception(httpx.TimeoutException("timed out"))
+    httpx_mock.add_response(url=ENDPOINT, method="POST", json={"status": "ok"})
+    result = await retrying_client.post_action({"action": "end_turn"})
+    assert result == {"status": "ok"}
+
+
+async def test_post_action_does_not_retry_on_http_error(
+    retrying_client: STS2Client, httpx_mock: HTTPXMock
+):
+    """HTTP 500 is not a transient failure — no retry, returns None immediately."""
+    httpx_mock.add_response(url=ENDPOINT, method="POST", status_code=500, text="error")
+    result = await retrying_client.post_action({"action": "end_turn"})
+    assert result is None
+    assert len(httpx_mock.get_requests()) == 1  # exactly one attempt
 
 
 # --- dry_run mode ---


### PR DESCRIPTION
## Summary

Closes #75 (consolidates #9 and #61).

### Part A — Production Hardening
- **httpx retry with exponential backoff** added to `STS2Client` and `MenuClient`; retries on `ConnectError`/`TimeoutException`, backoff doubles each attempt; fully configurable via `settings.yaml` (`http_retry_attempts`, `http_retry_backoff_seconds`)
- **TwitchIO reconnect guard**: `_connected_once` flag prevents "Bot is online!" double-announcement and redundant `_ready.set()` on reconnect; refreshes `broadcaster` on each `event_ready` fire
- Unhandled exception handling in `_event_runner` was already in place

### Part B — Code Hygiene (all 11 original items + 5 additional findings)
- Replaced `polling.py` inline state set with `KNOWN_STATES.keys() | IDLE_STATES` (#1)
- Promoted `_shop_item_available` → `shop_item_available` across `options.py`, `labels.py` (#2)
- Replaced index-and-break loop with `zip()` in `_log_within_state_changes` (#3)
- Fixed `crystal_sphere` error pattern to match all other `build_api_body` branches (#4)
- Consolidated all `_fetch_parsed_state()` inline sites — 4 sites in `client.py` + `_handle_rewards` (#6, #C)
- Extracted `_handle_deck_select_event` shared helper; two near-identical event handlers reduced to one-liners (#7)
- Hoisted `_VOTE_TYPES` to module-level `_REWARD_VOTE_TYPES: frozenset[str]` (#8)
- Broke long compound `if` across lines in `_handle_post_action` (#9)
- Wrapped bare `GameState.from_api_response` in `_handle_game_ended` with `try/except ValueError` (#10 — only real bug risk)
- Promoted `range(20)` → `settings.yaml` `end_game_screen_max_nav_attempts` (#11)
- Combined identical `shop`/`fake_merchant` branches in `build_api_body` (#A)
- Threaded `broadcaster` as explicit param through `_handle_rewards` and `_handle_belt_full_potion_discard` (#B)
- Added comment clarifying mutually-exclusive `if/elif` state-dispatch chain (#E)
- Removed dead `database:` section from `settings.yaml` (#D)

## Test plan
- [x] 195 tests passing (`python -m pytest`) — up from 191; 4 new retry unit tests added
- [x] `_REWARD_REWARD_VOTE_TYPES` NameError caught and fixed during live session
- [x] Full combat + shop live test not re-run after final fixes (accepted risk)
- [ ] TwitchIO reconnect untestable without forced disconnect (accepted risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)