### PR TITLE
feat(#84): parse player.max_potion_slots for proactive belt-full detection

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,9 +4,9 @@
 `PoC`
 
 ## Recently Completed
-- #82 — Vote-start delay: `start_delay_seconds` (default 0) under `vote:` in settings.yaml; set to 6 for stream latency; post-delay stale check prevents wasted vote windows on mid-delay state transitions; 195 tests
+- #84 — max_potion_slots: `player_max_potion_slots` parsed from STS2MCP API into `GameState`; `is_potion_belt_full()` helper on state; proactive belt-full pre-check in `_handle_rewards` skips claim attempt when belt known-full; fallback to attempt-then-react when field absent; 201 tests
+- #82 — Vote-start delay: `start_delay_seconds` (default 0) under `vote:` in settings.yaml; set to 6 for stream latency; post-delay stale check prevents wasted vote windows; 195 tests
 - #77 — fake_merchant: Foul Potion allowed at shop/fake_merchant (no target vote; API auto-infers merchant); 191 tests
-- #76 — Remove max_belt_size config: deleted `potions:` from settings/loader, dropped belt-full pre-check in `shop_item_available`, rewards now attempt-then-react; 191 tests
 - #75 — Pre-ship hardening & code cleanup: all 11 Part B hygiene items + 5 additional findings fixed; httpx retry with exponential backoff (configurable); TwitchIO reconnect guard; 195 tests
 
 ## Active Issue
@@ -22,7 +22,7 @@ None
 - All API URLs required via .env — no hardcoded defaults in committed files
 - Fail loud on missing config at startup
 - Logging at INFO level to terminal + `logs/bot.log` (truncated each run, gitignored)
-- Test suite: `python -m pytest` from project root; 195 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
+- Test suite: `python -m pytest` from project root; 201 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
 - STS2MCP API on `localhost:15526`; enemy `entity_id` lives at `battle.enemies[i].entity_id`

--- a/bot/client.py
+++ b/bot/client.py
@@ -956,6 +956,17 @@ class TwitchBot(commands.Bot):
                         skipped_indices.add(idx)
                     continue
 
+                # Belt capacity is known from API — skip the claim attempt; reactive fallbacks below cover old mod versions where max_potion_slots is absent
+                if is_potion and state.is_potion_belt_full() is True:
+                    logger.info(
+                        "Rewards: belt full (%d/%d) — triggering discard vote",
+                        len(state.player_potions), state.player_max_potion_slots,
+                    )
+                    winner = await self._handle_belt_full_potion_discard(broadcaster, state, auto_item)
+                    if winner == "skip":
+                        skipped_indices.add(idx)
+                    continue
+
                 await asyncio.sleep(self._auto_proceed_delay)
                 result = await self._game_client.post_action({"action": "claim_reward", "index": idx})
                 if result is None and is_potion:

--- a/game/state.py
+++ b/game/state.py
@@ -43,6 +43,7 @@ class GameState:
     card_select_cards: list[dict] = field(default_factory=list)      # card_select.cards (has name)
     shop_items: list[dict] = field(default_factory=list)             # shop.items or fake_merchant.shop.items
     player_potions: list[dict] = field(default_factory=list)         # player.potions (slot, name, target_type, can_use_in_combat, description)
+    player_max_potion_slots: int | None = None                       # player.max_potion_slots (None = old mod version)
 
     @classmethod
     def from_api_response(cls, data: dict) -> "GameState":
@@ -109,7 +110,14 @@ class GameState:
                 or []
             ),
             player_potions=player.get("potions") or [],
+            player_max_potion_slots=player.get("max_potion_slots"),
         )
+
+    def is_potion_belt_full(self) -> bool | None:
+        """Return True if belt is at capacity, False if space remains, None if capacity unknown."""
+        if self.player_max_potion_slots is None:
+            return None
+        return len(self.player_potions) >= self.player_max_potion_slots
 
     def is_combat_state(self) -> bool:
         """Return True when the current state is a combat encounter."""

--- a/tests/game/test_state.py
+++ b/tests/game/test_state.py
@@ -79,6 +79,17 @@ def test_from_api_response_parses_potions():
     assert state.player_potions[0]["name"] == "Fire Potion"
 
 
+def test_from_api_response_parses_max_potion_slots():
+    data = {**MINIMAL_COMBAT_RESPONSE, "player": {**MINIMAL_COMBAT_RESPONSE["player"], "max_potion_slots": 5}}
+    state = GameState.from_api_response(data)
+    assert state.player_max_potion_slots == 5
+
+
+def test_from_api_response_max_potion_slots_absent_is_none():
+    state = GameState.from_api_response(MINIMAL_COMBAT_RESPONSE)
+    assert state.player_max_potion_slots is None
+
+
 def test_from_api_response_shop_items_from_shop_key():
     data = {
         "state_type": "shop",
@@ -103,6 +114,44 @@ def test_from_api_response_null_nested_keys_dont_crash():
     assert state.act is None
     assert state.player_hp is None
     assert state.enemies == []
+
+
+# --- is_potion_belt_full ---
+
+def test_is_potion_belt_full_true_when_at_capacity():
+    state = GameState(
+        state_type="rewards", act=1, floor=1, player_hp=80, player_max_hp=80,
+        player_potions=[{"slot": 0}, {"slot": 1}, {"slot": 2}],
+        player_max_potion_slots=3,
+    )
+    assert state.is_potion_belt_full() is True
+
+
+def test_is_potion_belt_full_false_when_space_remains():
+    state = GameState(
+        state_type="rewards", act=1, floor=1, player_hp=80, player_max_hp=80,
+        player_potions=[{"slot": 0}],
+        player_max_potion_slots=3,
+    )
+    assert state.is_potion_belt_full() is False
+
+
+def test_is_potion_belt_full_none_when_capacity_unknown():
+    state = GameState(
+        state_type="rewards", act=1, floor=1, player_hp=80, player_max_hp=80,
+        player_potions=[{"slot": 0}, {"slot": 1}, {"slot": 2}],
+        player_max_potion_slots=None,
+    )
+    assert state.is_potion_belt_full() is None
+
+
+def test_is_potion_belt_full_false_when_empty_with_capacity():
+    state = GameState(
+        state_type="rewards", act=1, floor=1, player_hp=80, player_max_hp=80,
+        player_potions=[],
+        player_max_potion_slots=3,
+    )
+    assert state.is_potion_belt_full() is False
 
 
 # --- is_combat_state ---


### PR DESCRIPTION
## Summary

- Adds `player_max_potion_slots: int | None` to `GameState`, parsed from the new `player.max_potion_slots` field shipped in STS2MCP commit `bef22a5` (our request at Gennadiyev/STS2MCP#72)
- Adds `is_potion_belt_full() -> bool | None` on `GameState` — capacity logic lives in the state layer alongside `is_combat_state()`
- `_handle_rewards` now proactively checks belt capacity before attempting to claim a potion reward; skips straight to the discard vote when belt is known-full
- Returns `None` when `max_potion_slots` is absent (old mod versions), preserving existing attempt-then-react fallback paths unchanged

## Test plan

- [x] 201 tests pass (6 new: 2 parsing, 4 `is_potion_belt_full` method)
- [ ] Live: rewards screen with full belt triggers discard vote without a failed claim attempt in logs

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)