### PR TITLE
#86: Centralize vote-dispatch and sync chat prompt to stream latency

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,8 @@
 `PoC`
 
 ## Recently Completed
+- #86 — Vote stream-sync rework: chat prompt for first-detection votes now sleeps `stream_latency_seconds` before announcing, so the prompt arrives in sync with what stream-watchers see (chat is real-time; video is CDN-buffered). Sleep + stale-check centralized at `_event_runner` dispatcher (`_check_vote_dispatch`); sub-votes (target select, belt-full discard) bypass naturally. Replaced 5 scattered sleep sites (incl. 2 chat-leak bugs at smith and character-select where chat fired before the sleep). 207 tests
 - #84 — max_potion_slots: `player_max_potion_slots` parsed from STS2MCP API into `GameState`; `is_potion_belt_full()` helper on state; proactive belt-full pre-check in `_handle_rewards` skips claim attempt when belt known-full; fallback to attempt-then-react when field absent; 201 tests
-- #82 — Vote-start delay: `start_delay_seconds` (default 0) under `vote:` in settings.yaml; set to 6 for stream latency; post-delay stale check prevents wasted vote windows; 195 tests
 - #77 — fake_merchant: Foul Potion allowed at shop/fake_merchant (no target vote; API auto-infers merchant); 191 tests
 - #75 — Pre-ship hardening & code cleanup: all 11 Part B hygiene items + 5 additional findings fixed; httpx retry with exponential backoff (configurable); TwitchIO reconnect guard; 195 tests
 
@@ -13,16 +13,17 @@
 None
 
 ## Up Next
-1. #54 — Potion edge cases: combat-only filter for non-AnyEnemy potions
-2. #44 — Feature: end the run via supermajority chat vote
-3. #36 — Viewer info commands: deck/pile/relics/status lookup
+1. #87 — OBS browser-source overlay for vote prompts (CDN-synced visual sync, no flat delay needed)
+2. #54 — Potion edge cases: combat-only filter for non-AnyEnemy potions
+3. #44 — Feature: end the run via supermajority chat vote
+4. #36 — Viewer info commands: deck/pile/relics/status lookup
 
 ## Key Decisions
 - Bot and game run on same PC (localhost API)
 - All API URLs required via .env — no hardcoded defaults in committed files
 - Fail loud on missing config at startup
 - Logging at INFO level to terminal + `logs/bot.log` (truncated each run, gitignored)
-- Test suite: `python -m pytest` from project root; 201 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
+- Test suite: `python -m pytest` from project root; 207 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
 - STS2MCP API on `localhost:15526`; enemy `entity_id` lives at `battle.enemies[i].entity_id`

--- a/bot/client.py
+++ b/bot/client.py
@@ -286,7 +286,7 @@ class TwitchBot(commands.Bot):
         self.vote_manager = VoteManager(config["vote"]["duration_seconds"])
         self._target_vote_duration: float = config["vote"]["target_duration_seconds"]
         self._smith_vote_duration: float = config["vote"].get("smith_vote_duration_seconds", 30.0)
-        self._vote_start_delay: float = config["vote"].get("start_delay_seconds", 0.0)
+        self._stream_latency: float = config["vote"].get("stream_latency_seconds", 0.0)
         self._auto_proceed_delay: float = config["game"].get("auto_proceed_delay_seconds", 3.0)
 
         game_cfg = config["game"]
@@ -384,15 +384,22 @@ class TwitchBot(commands.Bot):
                 elif isinstance(event, GameEndedEvent):
                     await self._handle_game_ended(event)
                 elif isinstance(event, MenuSelectNeededEvent):
+                    if self._stream_latency > 0:
+                        await asyncio.sleep(self._stream_latency)
                     await self._handle_menu_select(broadcaster)
-                elif isinstance(event, VoteNeededEvent) and event.state.state_type == "rewards":
-                    await self._handle_rewards(broadcaster)
-                elif isinstance(event, VoteNeededEvent) and event.state.card_select_screen_type == "select":
-                    await self._handle_card_remove_event(event, broadcaster)
-                elif isinstance(event, VoteNeededEvent) and event.state.card_select_screen_type == "upgrade":
-                    await self._handle_smith_upgrade_event(event, broadcaster)
                 elif isinstance(event, VoteNeededEvent):
-                    await self._handle_vote_needed(event, broadcaster)
+                    fresh = await self._check_vote_dispatch(event.state)
+                    if fresh is None:
+                        continue
+                    fresh_event = event if fresh is event.state else VoteNeededEvent(fresh)
+                    if fresh.state_type == "rewards":
+                        await self._handle_rewards(broadcaster)
+                    elif fresh.card_select_screen_type == "select":
+                        await self._handle_card_remove_event(fresh_event, broadcaster)
+                    elif fresh.card_select_screen_type == "upgrade":
+                        await self._handle_smith_upgrade_event(fresh_event, broadcaster)
+                    else:
+                        await self._handle_vote_needed(fresh_event, broadcaster)
 
             except asyncio.CancelledError:
                 logger.info("Event runner cancelled")
@@ -434,6 +441,25 @@ class TwitchBot(commands.Bot):
             )
             return True
         return False
+
+    async def _check_vote_dispatch(self, event_state: GameState) -> GameState | None:
+        """Wait stream-latency, then re-fetch and stale-check before announcing the vote.
+
+        The pre-announce sleep keeps the chat prompt synced with what stream-watchers
+        see (chat is real-time; video is CDN-buffered). The post-sleep stale-check
+        discards the event if state changed during the wait.
+
+        Returns the freshest GameState to use for the vote, or None if the event
+        should be discarded. Fail-open on fetch failure (returns event_state).
+        """
+        if self._stream_latency > 0:
+            await asyncio.sleep(self._stream_latency)
+        fresh = await self._fetch_parsed_state()
+        if fresh is None:
+            return event_state
+        if self._is_stale_state(fresh, event_state.state_type, "vote"):
+            return None
+        return fresh
 
     async def _try_auto_proceed(self, state: GameState, broadcaster: twitchio.PartialUser) -> bool:
         """Try the 5 single-option auto-proceed shortcuts; return True if handled."""
@@ -521,16 +547,11 @@ class TwitchBot(commands.Bot):
         await self._handle_deck_select_event(broadcaster, "upgrade", "Smith upgrade", self._handle_smith_upgrade)
 
     async def _handle_vote_needed(self, event: VoteNeededEvent, broadcaster: twitchio.PartialUser) -> None:
-        """Handle a general VoteNeededEvent: stale-check, auto-proceed, vote, execute."""
-        pre_vote_state = await self._fetch_parsed_state()
+        """Handle a general VoteNeededEvent: auto-proceed shortcut, then run the vote."""
+        if await self._try_auto_proceed(event.state, broadcaster):
+            return
 
-        if pre_vote_state is not None:
-            if self._is_stale_state(pre_vote_state, event.state.state_type, "vote"):
-                return
-            if await self._try_auto_proceed(pre_vote_state, broadcaster):
-                return
-
-        vote_state = pre_vote_state if pre_vote_state is not None else event.state
+        vote_state = event.state
 
         # Event options may not be populated immediately after room transition — retry briefly.
         if vote_state.state_type == "event" and not vote_state.event_options:
@@ -542,13 +563,6 @@ class TwitchBot(commands.Bot):
                     break
             else:
                 logger.warning("Event state has no options after retries — falling back to static options")
-        await asyncio.sleep(self._vote_start_delay)
-        if self._vote_start_delay > 0:
-            post_delay_state = await self._fetch_parsed_state()
-            if post_delay_state is not None:
-                if self._is_stale_state(post_delay_state, event.state.state_type, "vote (post-delay)"):
-                    return
-                vote_state = post_delay_state
         winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,
@@ -727,7 +741,6 @@ class TwitchBot(commands.Bot):
         target_options = [str(i + 1) for i in range(len(enemies))]
         target_labels = target_labels_for_enemies(enemies)
 
-        await asyncio.sleep(self._vote_start_delay)
         target_winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,
@@ -824,7 +837,6 @@ class TwitchBot(commands.Bot):
         for chunk in _chunk_card_list(entries, separator=" | "):
             await self._chat(" | ".join(chunk))
 
-        await asyncio.sleep(self._vote_start_delay)
         winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,
@@ -898,7 +910,6 @@ class TwitchBot(commands.Bot):
         reward_name = potion_item.get("description") or "potion"
         preamble = f"Belt full! Discard a potion to claim {reward_name}, or !skip to pass."
 
-        await asyncio.sleep(self._vote_start_delay)
         winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,
@@ -1156,7 +1167,6 @@ class TwitchBot(commands.Bot):
         asc_str = f" | Ascension {ascension}" if ascension else ""
         await self._chat(f"Choose your character{asc_str}: {char_list}")
 
-        await asyncio.sleep(self._vote_start_delay)
         winner = await self.vote_manager.run_window(
             broadcaster=broadcaster,
             bot_id=self.bot_id,

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -8,7 +8,7 @@ vote:
   duration_seconds: 10  # How long each card/action voting window stays open
   target_duration_seconds: 10  # How long the target selection vote stays open
   smith_vote_duration_seconds: 30  # How long the smith upgrade card-selection vote stays open
-  start_delay_seconds: 6  # Delay before opening the vote window; set to your stream latency (e.g. 3)
+  stream_latency_seconds: 6  # Delay before announcing first-detection votes in chat, so the prompt arrives in sync with what stream-watchers see (chat is real-time; video is CDN-buffered). Set to your typical Twitch latency (e.g. 3 for Low Latency Mode, 6 for Normal). Sub-votes (target select, belt-full discard) skip the delay. 0 = no delay.
 
 game:
   poll_interval_seconds: 1     # How often to check STS2 game state

--- a/tests/bot/test_vote_start_delay.py
+++ b/tests/bot/test_vote_start_delay.py
@@ -1,0 +1,81 @@
+"""Tests for the centralized vote-dispatch flow: pre-announce sleep + staleness check."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bot.client import TwitchBot
+from game.state import GameState
+
+
+def _make_bot_for_dispatch_check(
+    fresh_state: GameState | None, stream_latency: float = 0.0
+) -> MagicMock:
+    bot = MagicMock(spec=TwitchBot)
+    bot._stream_latency = stream_latency
+    bot._fetch_parsed_state = AsyncMock(return_value=fresh_state)
+    bot._is_stale_state = lambda current, expected, ctx="vote": (
+        TwitchBot._is_stale_state(bot, current, expected, ctx)
+    )
+    return bot
+
+
+async def test_check_vote_dispatch_returns_fresh_state_when_stable():
+    event_state = GameState(state_type="event", act=1, floor=1, player_hp=80, player_max_hp=80)
+    fresh = GameState(state_type="event", act=1, floor=1, player_hp=75, player_max_hp=80)
+    bot = _make_bot_for_dispatch_check(fresh)
+
+    result = await TwitchBot._check_vote_dispatch(bot, event_state)
+
+    assert result is fresh
+    bot._fetch_parsed_state.assert_awaited_once()
+
+
+async def test_check_vote_dispatch_returns_none_on_state_type_mismatch():
+    event_state = GameState(state_type="event", act=1, floor=1, player_hp=80, player_max_hp=80)
+    fresh = GameState(state_type="map", act=1, floor=2, player_hp=80, player_max_hp=80)
+    bot = _make_bot_for_dispatch_check(fresh)
+
+    result = await TwitchBot._check_vote_dispatch(bot, event_state)
+
+    assert result is None
+
+
+async def test_check_vote_dispatch_returns_none_on_combat_enemy_turn():
+    event_state = GameState(state_type="monster", act=1, floor=2, player_hp=80, player_max_hp=80, is_play_phase=True)
+    fresh = GameState(state_type="monster", act=1, floor=2, player_hp=78, player_max_hp=80, is_play_phase=False)
+    bot = _make_bot_for_dispatch_check(fresh)
+
+    result = await TwitchBot._check_vote_dispatch(bot, event_state)
+
+    assert result is None
+
+
+async def test_check_vote_dispatch_fail_open_when_fetch_returns_none():
+    event_state = GameState(state_type="event", act=1, floor=1, player_hp=80, player_max_hp=80)
+    bot = _make_bot_for_dispatch_check(None)
+
+    result = await TwitchBot._check_vote_dispatch(bot, event_state)
+
+    assert result is event_state
+
+
+async def test_check_vote_dispatch_sleeps_stream_latency_before_fetch():
+    """Pre-announce sleep keeps the chat prompt synced with what stream-watchers see."""
+    event_state = GameState(state_type="event", act=1, floor=1, player_hp=80, player_max_hp=80)
+    fresh = GameState(state_type="event", act=1, floor=1, player_hp=75, player_max_hp=80)
+    bot = _make_bot_for_dispatch_check(fresh, stream_latency=5.0)
+
+    with patch("bot.client.asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+        result = await TwitchBot._check_vote_dispatch(bot, event_state)
+
+    assert result is fresh
+    sleep_mock.assert_awaited_once_with(5.0)
+
+
+async def test_check_vote_dispatch_zero_latency_skips_sleep():
+    event_state = GameState(state_type="event", act=1, floor=1, player_hp=80, player_max_hp=80)
+    fresh = GameState(state_type="event", act=1, floor=1, player_hp=75, player_max_hp=80)
+    bot = _make_bot_for_dispatch_check(fresh, stream_latency=0.0)
+
+    with patch("bot.client.asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+        await TwitchBot._check_vote_dispatch(bot, event_state)
+
+    sleep_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Replaces five scattered `asyncio.sleep` sites from #82 with a single pre-announce sleep in `_check_vote_dispatch` at the dispatcher, keeping chat prompts in sync with what stream-watchers see (chat is real-time; video is CDN-buffered by 2–15s)
- New `_check_vote_dispatch` helper: sleeps `stream_latency_seconds`, re-fetches state, stale-checks — all at a single dispatcher chokepoint. Sub-votes (target select, belt-full discard) called inside handlers bypass it naturally
- Fixes 2 chat-leak bugs where `_handle_deck_select_vote` and `_handle_menu_select` sent chat messages *before* the sleep, causing double-prompt ordering issues
- Renames `vote.start_delay_seconds` → `vote.stream_latency_seconds` in `config/settings.yaml` with updated comment explaining the flat-delay semantics
- `_handle_vote_needed` simplified: stale-check removed (now centralized at dispatcher), double-fetch eliminated (uses dispatcher-provided fresh state directly)

## Implementation note

The issue was originally scoped to an extended-duration model (open vote immediately, extend window). Mid-session this was revised to a flat-delay-on-announcement model after confirming that 100% of voters are stream-watchers — meaning the prompt must arrive *in sync with the video*, not just overlap it. The flat-delay approach is correct for this audience; the dispatcher centralization and stale-check are kept as they stand independent of the timing model.

`stream_latency_seconds` can be set to `0` permanently once #87 (OBS browser-source overlay) ships — the overlay renders the prompt into the video frame before encoding, eliminating the CDN sync gap entirely.

## Test plan

- [x] 207 tests pass (`python -m pytest`) — 6 new tests in `tests/bot/test_vote_start_delay.py` covering dispatcher stale-check (4 cases) and sleep behavior (2 cases)
- [x] Live: chat prompt now arrives in sync with what stream-watchers see on screen
- [x] Live: chat-leak bugs at smith upgrade and character select confirmed fixed
- [ ] Sub-votes (target select, belt-full discard) at base duration only — inferred from code, not directly observed live

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)