### PR TITLE
feat(#88): run-start welcome + per-state-entry announcements

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,10 +4,10 @@
 `PoC`
 
 ## Recently Completed
+- #88 — UX polish: run-start welcome at character-select (voting intro + command reference, fires once per run); per-state-entry announcements for combat/boss/shop/treasure/relic/rest/event; act-transition lines; suppressed on mid-state re-queues; 234 tests
 - #86 — Vote stream-sync rework: chat prompt for first-detection votes now sleeps `stream_latency_seconds` before announcing, so the prompt arrives in sync with what stream-watchers see (chat is real-time; video is CDN-buffered). Sleep + stale-check centralized at `_event_runner` dispatcher (`_check_vote_dispatch`); sub-votes (target select, belt-full discard) bypass naturally. Replaced 5 scattered sleep sites (incl. 2 chat-leak bugs at smith and character-select where chat fired before the sleep). 207 tests
 - #84 — max_potion_slots: `player_max_potion_slots` parsed from STS2MCP API into `GameState`; `is_potion_belt_full()` helper on state; proactive belt-full pre-check in `_handle_rewards` skips claim attempt when belt known-full; fallback to attempt-then-react when field absent; 201 tests
 - #77 — fake_merchant: Foul Potion allowed at shop/fake_merchant (no target vote; API auto-infers merchant); 191 tests
-- #75 — Pre-ship hardening & code cleanup: all 11 Part B hygiene items + 5 additional findings fixed; httpx retry with exponential backoff (configurable); TwitchIO reconnect guard; 195 tests
 
 ## Active Issue
 None
@@ -23,7 +23,7 @@ None
 - All API URLs required via .env — no hardcoded defaults in committed files
 - Fail loud on missing config at startup
 - Logging at INFO level to terminal + `logs/bot.log` (truncated each run, gitignored)
-- Test suite: `python -m pytest` from project root; 207 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
+- Test suite: `python -m pytest` from project root; 234 tests, no live deps; `bot/client.py` not tested (twitchio mocking complexity)
 - GitHub Issues for all task tracking; Claude can create/label/prioritize autonomously
 - `PROGRESS.md` stays capped at ~20-30 lines; full history lives in GitHub Issues
 - STS2MCP API on `localhost:15526`; enemy `entity_id` lives at `battle.enemies[i].entity_id`

--- a/bot/client.py
+++ b/bot/client.py
@@ -21,6 +21,39 @@ logger = logging.getLogger(__name__)
 _WIKI_BASE = "https://slaythespire.wiki.gg/wiki/Slay_the_Spire_2:"
 _REWARD_VOTE_TYPES: frozenset[str] = frozenset({"card", "special_card", "card_removal"})
 
+_HELP_TEXT = (
+    "Commands: !N=vote for option N | !pN=play potion N | !dN=discard potion N"
+    " | ?map=map preview | ?p=potion belt | ?N=card in slot N | ((name))=card lookup"
+)
+
+
+def _format_state_announcement(state: GameState) -> str | None:
+    """Return a one-line chat announcement for entering this state, or None to skip.
+
+    Skipped state_types (map, rewards, card_select, etc.) return None so the caller
+    can suppress the announcement without a special-case branch.
+    """
+    if state.is_combat_state():
+        header = "👑 BOSS" if state.state_type == "boss" else "⚔️ Combat"
+        parts = [
+            f"{e.get('name', 'Enemy')} ({e.get('hp', '?')}/{e.get('max_hp', '?')})"
+            for e in state.enemies
+        ]
+        return f"{header} — {', '.join(parts)}" if parts else header
+    st = state.state_type
+    if st in ("shop", "fake_merchant"):
+        gold = state.player_gold if state.player_gold is not None else "?"
+        return f"🛒 Shop — Gold: {gold}"
+    if st == "treasure":
+        return "💎 Treasure room"
+    if st == "relic_select":
+        return "🎁 Relic offered"
+    if st == "rest_site":
+        return "🛌 Rest site"
+    if st == "event":
+        return "❓ Event"
+    return None
+
 
 def _chunk_card_list(
     entries: list[str], max_len: int = 490, separator: str = " | "
@@ -128,10 +161,7 @@ class ChatComponent(commands.Component):
 
     async def _handle_help(self) -> None:
         """Respond to !help with a concise viewer command reference."""
-        await self._send_chat(
-            "Commands: !N=vote | !pN=use potion N | !dN=discard potion N"
-            " | ?map=map preview | ?p/?potions=potion belt | ?N=card in slot N | ((name))=card lookup"
-        )
+        await self._send_chat(_HELP_TEXT)
 
     async def _handle_slot_lookup(self, arg: str) -> None:
         """Respond to ?N with card info for vote slot N from the current hand."""
@@ -307,6 +337,11 @@ class TwitchBot(commands.Bot):
         self._ready = asyncio.Event()  # set in event_ready; gates _event_runner
         self._connected_once = False   # guards against double-announce on TwitchIO reconnect
 
+        # Announcement tracking — reset on GameEndedEvent so each run starts fresh.
+        self._welcome_sent: bool = False
+        self._last_announced_state_key: str | None = None
+        self._last_seen_act: int | None = None
+
         super().__init__(
             client_id=config["twitch"]["client_id"],
             client_secret=config["twitch"]["client_secret"],
@@ -337,6 +372,48 @@ class TwitchBot(commands.Bot):
             sender=self.bot_id,
             token_for=self.bot_id,
         )
+
+    async def _send_run_welcome(self) -> None:
+        """Onboard chat at character-select once per run.
+
+        Fires on the first character-select since bot start or last GameEndedEvent.
+        """
+        if self._welcome_sent:
+            return
+        self._welcome_sent = True
+        duration = int(self.vote_manager.duration)
+        await self._chat(
+            f"🎬 A new run is starting! Pick a character below — "
+            f"most-voted wins each {duration}s vote window."
+        )
+        await self._chat(
+            "How to vote: !N=pick option N | !pN=play potion N | !dN=discard potion N"
+        )
+        await self._chat(
+            "Info commands: !help | ?map | ?p (potion belt) | "
+            "?N (card in hand slot N) | ((card name)) (lookup any card)"
+        )
+
+    async def _announce_state_entry(self, state: GameState) -> None:
+        """Send a one-line chat announcement on first entry into a new state.
+
+        Suppressed when the same state_type+act+floor was just announced (within-state
+        re-queues, e.g. mid-combat hand changes). Also fires an act-transition line
+        when crossing into a new act.
+        """
+        if state.act is not None and state.act != self._last_seen_act:
+            if self._last_seen_act is not None:
+                await self._chat(f"🎬 Entering Act {state.act}!")
+            self._last_seen_act = state.act
+
+        key = f"{state.state_type}:{state.act}:{state.floor}"
+        if key == self._last_announced_state_key:
+            return
+        self._last_announced_state_key = key
+
+        msg = _format_state_announcement(state)
+        if msg is not None:
+            await self._chat(msg)
 
     async def event_ready(self) -> None:
         users = await self.fetch_users(ids=[self._owner_id])
@@ -547,7 +624,8 @@ class TwitchBot(commands.Bot):
         await self._handle_deck_select_event(broadcaster, "upgrade", "Smith upgrade", self._handle_smith_upgrade)
 
     async def _handle_vote_needed(self, event: VoteNeededEvent, broadcaster: twitchio.PartialUser) -> None:
-        """Handle a general VoteNeededEvent: auto-proceed shortcut, then run the vote."""
+        """Handle a general VoteNeededEvent: announce state entry, auto-proceed shortcut, then run the vote."""
+        await self._announce_state_entry(event.state)
         if await self._try_auto_proceed(event.state, broadcaster):
             return
 
@@ -1005,6 +1083,10 @@ class TwitchBot(commands.Bot):
     async def _handle_game_ended(self, event: GameEndedEvent) -> None:
         """Send end-of-run announcement, navigate post-run screens back to menu, then announce countdown."""
         logger.info("Game ended: %s", event.state.summary())
+        # Reset announcement flags so each new run gets a fresh welcome + state entries.
+        self._welcome_sent = False
+        self._last_announced_state_key = None
+        self._last_seen_act = None
         await self._chat("Run over! Thanks for playing.")
 
         # Navigate defeat/victory/unlock screens back to menu.
@@ -1165,6 +1247,7 @@ class TwitchBot(commands.Bot):
             f"!{opt}={_fmt(enabled[int(opt) - 1]['character_id'])}" for opt in options
         )
         asc_str = f" | Ascension {ascension}" if ascension else ""
+        await self._send_run_welcome()
         await self._chat(f"Choose your character{asc_str}: {char_list}")
 
         winner = await self.vote_manager.run_window(

--- a/bot/vote_manager.py
+++ b/bot/vote_manager.py
@@ -22,6 +22,10 @@ class VoteManager:
         self._options: frozenset[str] = frozenset()
 
     @property
+    def duration(self) -> float:
+        return self._duration
+
+    @property
     def is_open(self) -> bool:
         return self._open
 

--- a/tests/bot/test_announcements.py
+++ b/tests/bot/test_announcements.py
@@ -1,0 +1,328 @@
+"""Tests for state-entry announcements and run-welcome onboarding (#88)."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bot.client import TwitchBot, _format_state_announcement
+from game.events import GameEndedEvent
+from game.state import GameState
+
+
+def _state(state_type: str, **kwargs) -> GameState:
+    """Build a GameState with sensible defaults for announcement tests."""
+    defaults = dict(act=1, floor=1, player_hp=80, player_max_hp=80)
+    defaults.update(kwargs)
+    return GameState(state_type=state_type, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# _format_state_announcement — pure formatter
+# ---------------------------------------------------------------------------
+
+def test_format_combat_monster_includes_enemy_hp():
+    state = _state(
+        "monster",
+        enemies=[
+            {"name": "Cultist", "hp": 20, "max_hp": 48, "entity_id": "e1"},
+            {"name": "Acid Slime", "hp": 32, "max_hp": 32, "entity_id": "e2"},
+        ],
+    )
+    msg = _format_state_announcement(state)
+    assert msg is not None
+    assert msg.startswith("⚔️ Combat")
+    assert "Cultist (20/48)" in msg
+    assert "Acid Slime (32/32)" in msg
+
+
+def test_format_combat_elite_uses_combat_header():
+    state = _state(
+        "elite",
+        enemies=[{"name": "Sentry", "hp": 40, "max_hp": 40, "entity_id": "e1"}],
+    )
+    msg = _format_state_announcement(state)
+    assert msg is not None
+    assert msg.startswith("⚔️ Combat")
+
+
+def test_format_boss_uses_boss_header():
+    state = _state(
+        "boss",
+        enemies=[{"name": "Hexaghost", "hp": 250, "max_hp": 250, "entity_id": "e1"}],
+    )
+    msg = _format_state_announcement(state)
+    assert msg is not None
+    assert msg.startswith("👑 BOSS")
+    assert "Hexaghost (250/250)" in msg
+
+
+def test_format_combat_with_no_enemies_falls_back_to_header_only():
+    state = _state("monster", enemies=[])
+    msg = _format_state_announcement(state)
+    assert msg == "⚔️ Combat"
+
+
+def test_format_shop_includes_player_gold():
+    state = _state("shop", player_gold=137)
+    msg = _format_state_announcement(state)
+    assert msg == "🛒 Shop — Gold: 137"
+
+
+def test_format_fake_merchant_uses_shop_header():
+    state = _state("fake_merchant", player_gold=42)
+    msg = _format_state_announcement(state)
+    assert msg is not None
+    assert msg.startswith("🛒 Shop")
+    assert "42" in msg
+
+
+def test_format_shop_handles_missing_gold():
+    state = _state("shop", player_gold=None)
+    msg = _format_state_announcement(state)
+    assert msg == "🛒 Shop — Gold: ?"
+
+
+def test_format_treasure_room():
+    assert _format_state_announcement(_state("treasure")) == "💎 Treasure room"
+
+
+def test_format_relic_select():
+    assert _format_state_announcement(_state("relic_select")) == "🎁 Relic offered"
+
+
+def test_format_rest_site():
+    assert _format_state_announcement(_state("rest_site")) == "🛌 Rest site"
+
+
+def test_format_event():
+    assert _format_state_announcement(_state("event")) == "❓ Event"
+
+
+def test_format_map_returns_none():
+    assert _format_state_announcement(_state("map")) is None
+
+
+def test_format_rewards_returns_none():
+    assert _format_state_announcement(_state("rewards")) is None
+
+
+def test_format_card_select_returns_none():
+    assert _format_state_announcement(_state("card_select")) is None
+
+
+# ---------------------------------------------------------------------------
+# _announce_state_entry — bot-level dispatch + suppression
+# ---------------------------------------------------------------------------
+
+def _make_announcer_bot() -> MagicMock:
+    bot = MagicMock(spec=TwitchBot)
+    bot._chat = AsyncMock()
+    bot._welcome_sent = False
+    bot._last_announced_state_key = None
+    bot._last_seen_act = None
+    return bot
+
+
+async def test_announce_state_entry_first_call_sends_chat():
+    bot = _make_announcer_bot()
+    state = _state("treasure", act=1, floor=3)
+
+    await TwitchBot._announce_state_entry(bot, state)
+
+    bot._chat.assert_awaited_once()
+    assert "Treasure" in bot._chat.call_args.args[0]
+    assert bot._last_announced_state_key == "treasure:1:3"
+
+
+async def test_announce_state_entry_same_state_is_suppressed():
+    """Within-state re-queues (e.g. mid-combat hand changes) must NOT re-announce."""
+    bot = _make_announcer_bot()
+    state = _state(
+        "monster", act=1, floor=4,
+        enemies=[{"name": "Jaw Worm", "hp": 42, "max_hp": 42, "entity_id": "e1"}],
+    )
+
+    await TwitchBot._announce_state_entry(bot, state)
+    await TwitchBot._announce_state_entry(bot, state)
+
+    assert bot._chat.await_count == 1
+
+
+async def test_announce_state_entry_different_floor_re_announces():
+    bot = _make_announcer_bot()
+    s1 = _state("treasure", act=1, floor=3)
+    s2 = _state("treasure", act=1, floor=9)
+
+    await TwitchBot._announce_state_entry(bot, s1)
+    await TwitchBot._announce_state_entry(bot, s2)
+
+    assert bot._chat.await_count == 2
+
+
+async def test_announce_state_entry_first_act_does_not_send_act_line():
+    """Initial state of run records act=1 silently — welcome handles run-start framing."""
+    bot = _make_announcer_bot()
+    state = _state("treasure", act=1, floor=1)
+
+    await TwitchBot._announce_state_entry(bot, state)
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert not any("Entering Act" in t for t in texts)
+    assert bot._last_seen_act == 1
+
+
+async def test_announce_state_entry_act_change_sends_act_line():
+    bot = _make_announcer_bot()
+    bot._last_seen_act = 1
+    bot._last_announced_state_key = "treasure:1:9"
+    state = _state("monster", act=2, floor=10,
+                   enemies=[{"name": "Slime", "hp": 10, "max_hp": 10, "entity_id": "e1"}])
+
+    await TwitchBot._announce_state_entry(bot, state)
+
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert any("Entering Act 2" in t for t in texts)
+    assert any("⚔️ Combat" in t for t in texts)
+    assert bot._last_seen_act == 2
+
+
+async def test_announce_state_entry_skips_chat_for_unannounced_types_but_records_key():
+    """map state has no announcement copy, but the key is still recorded so
+    the next true state-entry isn't blocked."""
+    bot = _make_announcer_bot()
+    state = _state("map", act=1, floor=2)
+
+    await TwitchBot._announce_state_entry(bot, state)
+
+    bot._chat.assert_not_awaited()
+    assert bot._last_announced_state_key == "map:1:2"
+
+
+async def test_announce_state_entry_returns_to_same_state_after_intervening_does_re_announce():
+    """treasure → map → treasure (different floor) re-fires; suppression is by exact key, not type."""
+    bot = _make_announcer_bot()
+
+    await TwitchBot._announce_state_entry(bot, _state("treasure", act=1, floor=3))
+    await TwitchBot._announce_state_entry(bot, _state("map", act=1, floor=3))
+    await TwitchBot._announce_state_entry(bot, _state("treasure", act=1, floor=6))
+
+    treasure_msgs = [
+        c for c in bot._chat.call_args_list if "Treasure" in c.args[0]
+    ]
+    assert len(treasure_msgs) == 2
+
+
+# ---------------------------------------------------------------------------
+# _send_run_welcome — character-select onboarding
+# ---------------------------------------------------------------------------
+
+def _make_welcome_bot() -> MagicMock:
+    bot = MagicMock(spec=TwitchBot)
+    bot._chat = AsyncMock()
+    bot._welcome_sent = False
+    bot.vote_manager = MagicMock()
+    bot.vote_manager.duration = 60.0
+    return bot
+
+
+async def test_send_run_welcome_fires_three_messages():
+    bot = _make_welcome_bot()
+
+    await TwitchBot._send_run_welcome(bot)
+
+    assert bot._chat.await_count == 3
+    texts = [c.args[0] for c in bot._chat.call_args_list]
+    assert any("new run is starting" in t for t in texts)
+    assert any("How to vote" in t for t in texts)
+    assert any("Info commands" in t for t in texts)
+
+
+async def test_send_run_welcome_clarifies_potion_play_and_discard():
+    """User feedback: !pN and !dN must be obviously play/discard, not generic 'use'."""
+    bot = _make_welcome_bot()
+
+    await TwitchBot._send_run_welcome(bot)
+
+    texts = " ".join(c.args[0] for c in bot._chat.call_args_list)
+    assert "play potion" in texts.lower()
+    assert "discard potion" in texts.lower()
+
+
+async def test_send_run_welcome_includes_vote_window_seconds():
+    bot = _make_welcome_bot()
+    bot.vote_manager.duration = 45.0
+
+    await TwitchBot._send_run_welcome(bot)
+
+    texts = " ".join(c.args[0] for c in bot._chat.call_args_list)
+    assert "45s" in texts
+
+
+async def test_send_run_welcome_only_fires_once_per_run():
+    bot = _make_welcome_bot()
+
+    await TwitchBot._send_run_welcome(bot)
+    await TwitchBot._send_run_welcome(bot)
+
+    assert bot._chat.await_count == 3  # first call only; second is no-op
+    assert bot._welcome_sent is True
+
+
+# ---------------------------------------------------------------------------
+# _handle_game_ended — flag reset
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    monkeypatch.setattr("bot.client.asyncio.sleep", AsyncMock())
+
+
+async def test_handle_game_ended_resets_announcement_flags(no_sleep):
+    """End-of-run must reset welcome + state-entry tracking so next run is fresh."""
+    bot = MagicMock(spec=TwitchBot)
+    bot._chat = AsyncMock()
+    bot._end_game_screen_pause = 0.0
+    bot._end_game_screen_max_nav_attempts = 0  # short-circuit nav loop
+    bot._new_game_countdown = 0.0
+    bot._timeline_epoch_claim_delay = 0.0
+    bot._game_client = MagicMock()
+    bot._game_client.get_state = AsyncMock(return_value=None)
+    bot._menu_client = MagicMock()
+    bot._menu_client.get_menu_state = AsyncMock(return_value={"screen": "MAIN_MENU"})
+
+    bot._welcome_sent = True
+    bot._last_announced_state_key = "treasure:2:14"
+    bot._last_seen_act = 2
+
+    end_event = GameEndedEvent(state=GameState(
+        state_type="overlay", act=2, floor=14, player_hp=0, player_max_hp=70
+    ))
+    await TwitchBot._handle_game_ended(bot, end_event)
+
+    assert bot._welcome_sent is False
+    assert bot._last_announced_state_key is None
+    assert bot._last_seen_act is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_vote_needed — announcement runs before auto_proceed / vote
+# ---------------------------------------------------------------------------
+
+async def test_handle_vote_needed_announces_state_entry_before_auto_proceed():
+    """Treasure auto-proceeds, but the entry announcement must still fire so chat
+    isn't left silent on rooms that resolve without a vote."""
+    from game.events import VoteNeededEvent
+
+    bot = MagicMock(spec=TwitchBot)
+    bot._announce_state_entry = AsyncMock()
+    bot._try_auto_proceed = AsyncMock(return_value=True)
+
+    state = _state(
+        "treasure", act=1, floor=3,
+        treasure_relics=[{"index": 0, "name": "Burning Blood"}],
+    )
+    broadcaster = MagicMock()
+
+    await TwitchBot._handle_vote_needed(bot, VoteNeededEvent(state), broadcaster)
+
+    bot._announce_state_entry.assert_awaited_once_with(state)
+    bot._try_auto_proceed.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Welcome message fires at character-select (once per run, resets on GameEndedEvent): explains `!N` voting, `!pN`=play potion N, `!dN`=discard potion N, and info commands (`?map`, `?p`, `?N`, `((card))`)
- Per-state-entry announcement before each vote window: `⚔️ Combat — Enemy (hp/max)`, `👑 BOSS`, `🛒 Shop — Gold: N`, `💎 Treasure room`, `🎁 Relic offered`, `🛌 Rest site`, `❓ Event`
- Act-transition line (`🎬 Entering Act N!`) when crossing acts; suppressed on the first act (welcome already frames run-start)
- Suppression by `state_type:act:floor` key prevents re-announcing on within-state re-queues (e.g. mid-combat hand changes)
- `VoteManager.duration` public property added (was only `_duration` private)
- `_HELP_TEXT` constant extracted; `_handle_help` and welcome share consistent command wording

## Test plan

- [ ] `python -m pytest` — 234 tests, all green (207 → +27 new in `tests/bot/test_announcements.py`)
- [ ] Live: start bot at menu → character-select → verify 3-line welcome appears once
- [ ] Live: pick character → enter first combat → verify `⚔️ Combat — …` appears before vote
- [ ] Live: play a card mid-combat (re-queue) → verify combat line does NOT re-fire
- [ ] Live: walk map into shop → verify `🛒 Shop — Gold: N` appears
- [ ] Live: reach act 2 → verify `🎬 Entering Act 2!` line
- [ ] Live: end run → start new run → welcome fires again

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)