### PR TITLE
skill improvements: branch-hygiene gate + end-session verification labels

### DIFF
--- a/.claude/commands/end-session/SKILL.md
+++ b/.claude/commands/end-session/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: end-session
+description: Close out a working session by updating PROGRESS.md, closing the GitHub Issue, and ensuring the branch is committed and pushed. Use when the active issue's acceptance criteria are met.
+---
+
+1. Read `PROGRESS.md` to confirm the active issue.
+
+2. Check the active GitHub Issue with `gh issue view {number}` and do a **thorough** verification of all acceptance criteria. For each criterion, assign exactly one label:
+   - **CONFIRMED** — directly observed during a live test in this session
+   - **INFERRED** — code looks correct but not directly observed
+   - **UNVERIFIED** — not checked at all
+
+   **Hard stop:** If ANY criterion is INFERRED or UNVERIFIED, stop and ask the user: "The following criteria were not directly observed during live testing: [list]. Spot-check before closing, or accept the risk and close anyway?" Do NOT close until you receive an explicit reply. "Code looks correct" never counts as CONFIRMED.
+
+   **Re-test gate:** If a bug was discovered and fixed during live testing this session, it cannot be labeled CONFIRMED unless it was re-tested live *after* the fix. A code-only review of a fix is INFERRED.
+
+   Do not close the issue until the user explicitly confirms all criteria are satisfied.
+
+3. Update `PROGRESS.md` **before asking the user to commit**:
+   - Move the active issue to Recently Completed
+   - Clear the Active Issue field
+   - Update Up Next based on open GitHub Issues
+   - Keep the file capped at ~20-30 lines
+
+4. Check git state with `git status`:
+   - If there are uncommitted changes (including the PROGRESS.md update), flag them and stop — remind the user to commit before closing out.
+   - If there are unpushed commits, flag them and suggest pushing.
+
+5. Show the user a summary of what will be closed and ask for explicit confirmation before proceeding.
+
+6. After confirmation:
+   - Close the GitHub Issue with `gh issue close {number} --comment "Completed in session."`
+   - Do NOT commit, push, or merge branches — wait for explicit user instruction.

--- a/.claude/commands/start-session/SKILL.md
+++ b/.claude/commands/start-session/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: start-session
+description: Orient Claude at the start of a new session by reading project context and recommending next steps. Use at the beginning of every working session.
+---
+
+0. **Branch hygiene — do this before reading any files:**
+   - Run `git branch --show-current`. If not on `main`, run `git checkout main` before anything else.
+   - Run `git fetch origin && git pull origin main` to ensure you are on the latest commit.
+   - Do not read `PROGRESS.md`, list issues, or explore the codebase until you have confirmed you are on an up-to-date `main`. This step cannot be skipped or deferred.
+
+1. Read `PROGRESS.md` in the project root to understand current state.
+
+2. Read `CLAUDE.md` in the project root to understand project conventions and structure.
+
+3. Check open GitHub Issues with `gh issue list --state open` to see the current backlog.
+
+4. Check git state:
+   - Run `git status` and `git log origin/HEAD..HEAD` to check for uncommitted changes and unpushed commits.
+   - Run `git log HEAD..origin/HEAD` to check if the current branch is behind remote.
+   - If there are uncommitted changes, flag them — do not create a branch until resolved.
+   - If there are unpushed commits, flag them and suggest pushing.
+   - If the branch is behind remote, pull before proceeding: `git pull`.
+   - List all existing branches matching `issue-{active-issue-number}/*` to determine the next session number (e.g., if `issue-2/poc-bot-s1` exists, next is `s2`). If no such branches exist, start at `s1`.
+   - Do NOT create the branch yet — just determine the name.
+
+5. Summarize in plain language and then ask the user to confirm before proceeding:
+   - What milestone we're on
+   - What was recently completed
+   - What the recommended next action is and why
+   - What branch will be created upon confirmation: `issue-{number}/{short-description}-s{n}`
+
+6. After the user confirms the direction, create and switch to the session branch.
+
+Do not ask for input before completing steps 0-4. Orient, report, and then ask for confirmation.
+
+## Session constraints — enforce these for the entire session
+
+- Work on exactly one active GitHub Issue per session. Do not implement anything outside its scope.
+- If out-of-scope work is identified, create a GitHub Issue for it and stop — do not implement it.
+- Never commit or push without explicit user request.
+- When updating `PROGRESS.md`, keep it capped at ~20-30 lines. Drop older completed items as new ones are added. Full history lives in GitHub Issues.

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ htmlcov/
 
 # macOS
 .DS_Store
+
+# Claude Code
+.claude/settings.local.json
+.claude/worktrees/

--- a/scripts/validate_skill_amendments.py
+++ b/scripts/validate_skill_amendments.py
@@ -1,0 +1,184 @@
+"""
+Dry-run validation for skill-improvements/auto-v1.
+
+Simulates the two new skill gates against the historical failure scenarios
+from the /insights 50-session analysis. Each scenario shows what the old
+skill would have done (silent pass) vs what the new step catches (hard stop).
+
+Run with: python3 scripts/validate_skill_amendments.py
+"""
+
+import subprocess
+import sys
+
+
+PASS = "\033[32mPASS\033[0m"
+FAIL = "\033[31mFAIL\033[0m"
+CATCH = "\033[33mCATCHES\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# start-session Step 0: branch hygiene gate
+# ---------------------------------------------------------------------------
+
+def _current_branch() -> str:
+    return subprocess.check_output(
+        ["git", "branch", "--show-current"], text=True
+    ).strip()
+
+
+def simulate_start_session_branch_check(branch: str) -> dict:
+    """
+    Simulate the new Step 0 logic against a given branch name.
+    Returns {"caught": bool, "message": str}.
+    """
+    if branch != "main":
+        return {
+            "caught": True,
+            "message": (
+                f"[Step 0 HARD STOP] Current branch is '{branch}', not 'main'. "
+                "Run `git checkout main && git pull origin main` before proceeding."
+            ),
+        }
+    return {"caught": False, "message": "[Step 0] On main — proceeding."}
+
+
+# ---------------------------------------------------------------------------
+# end-session Step 2: CONFIRMED / INFERRED / UNVERIFIED gate
+# ---------------------------------------------------------------------------
+
+def simulate_end_session_criteria_check(criteria: list[dict]) -> dict:
+    """
+    Simulate the new Step 2 hard-stop logic.
+    criteria: list of {"label": str, "description": str, "label": "CONFIRMED"|"INFERRED"|"UNVERIFIED"}
+    Returns {"caught": bool, "flagged": list, "message": str}.
+    """
+    flagged = [c for c in criteria if c["status"] in ("INFERRED", "UNVERIFIED")]
+    if flagged:
+        names = [c["description"] for c in flagged]
+        return {
+            "caught": True,
+            "flagged": flagged,
+            "message": (
+                "[Step 2 HARD STOP] The following criteria were not directly observed "
+                f"during live testing: {names}. "
+                "Spot-check before closing, or accept the risk and close anyway?"
+            ),
+        }
+    return {"caught": False, "flagged": [], "message": "[Step 2] All criteria CONFIRMED — safe to close."}
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+def run_scenarios() -> int:
+    failures = 0
+
+    print("=" * 65)
+    print("start-session Step 0 — branch hygiene gate")
+    print("=" * 65)
+
+    scenarios_start = [
+        # Historical failure: Claude started on a non-main feature branch
+        # (user had to interrupt mid-session — noted twice in insights)
+        {
+            "name": "Non-main branch (historical: branched from wrong commit)",
+            "branch": "issue-77/fake-merchant-s1",
+            "expect_caught": True,
+        },
+        # Historical failure: Claude started on a detached HEAD / stale branch
+        {
+            "name": "Stale session branch (historical: session started before pull)",
+            "branch": "issue-84/potion-slots-s2",
+            "expect_caught": True,
+        },
+        # Happy path: already on main
+        {
+            "name": "Already on main (should pass through)",
+            "branch": "main",
+            "expect_caught": False,
+        },
+    ]
+
+    for s in scenarios_start:
+        result = simulate_start_session_branch_check(s["branch"])
+        ok = result["caught"] == s["expect_caught"]
+        status = PASS if ok else FAIL
+        marker = CATCH if result["caught"] else "pass"
+        print(f"  [{status}] {s['name']}")
+        print(f"         -> {marker}: {result['message']}")
+        if not ok:
+            failures += 1
+    print()
+
+    print("=" * 65)
+    print("end-session Step 2 — CONFIRMED / INFERRED / UNVERIFIED gate")
+    print("=" * 65)
+
+    scenarios_end = [
+        # Historical failure: PR #26 — Claude self-confirmed criteria as "code
+        # looks correct" without live test. Insights flagged this by name.
+        {
+            "name": "PR #26 pattern — criteria inferred, not live-tested",
+            "criteria": [
+                {"description": "Vote window opens on first card detection", "status": "CONFIRMED"},
+                {"description": "Winning vote sent to game API", "status": "INFERRED"},
+                {"description": "Chat notified of result", "status": "INFERRED"},
+            ],
+            "expect_caught": True,
+        },
+        # Historical failure: polling bug / OAuth issue — fix was shipped
+        # after code review only, without re-live-testing the fix.
+        {
+            "name": "Post-fix re-test gap (historical: fix shipped after code review only)",
+            "criteria": [
+                {"description": "Polling resumes after Soul card", "status": "INFERRED"},
+                {"description": "No stale-vote capture on retry", "status": "UNVERIFIED"},
+            ],
+            "expect_caught": True,
+        },
+        # Historical failure: oauth issue — criteria partially confirmed but one missed
+        {
+            "name": "Partial confirmation (one unverified criterion slips through)",
+            "criteria": [
+                {"description": "OAuth token refreshes correctly", "status": "CONFIRMED"},
+                {"description": "Reconnects on token expiry", "status": "UNVERIFIED"},
+            ],
+            "expect_caught": True,
+        },
+        # Happy path: all CONFIRMED
+        {
+            "name": "All criteria confirmed live (should close cleanly)",
+            "criteria": [
+                {"description": "Combat vote opens on enemy detection", "status": "CONFIRMED"},
+                {"description": "Target selection sub-vote fires", "status": "CONFIRMED"},
+            ],
+            "expect_caught": False,
+        },
+    ]
+
+    for s in scenarios_end:
+        result = simulate_end_session_criteria_check(s["criteria"])
+        ok = result["caught"] == s["expect_caught"]
+        status = PASS if ok else FAIL
+        marker = CATCH if result["caught"] else "pass"
+        print(f"  [{status}] {s['name']}")
+        print(f"         -> {marker}: {result['message']}")
+        if not ok:
+            failures += 1
+    print()
+
+    print("=" * 65)
+    total = len(scenarios_start) + len(scenarios_end)
+    passed = total - failures
+    print(f"Results: {passed}/{total} scenarios behave as expected")
+    if failures:
+        print(f"  {failures} scenario(s) did not match expected gate behaviour — review logic above.")
+    print("=" * 65)
+
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(run_scenarios())


### PR DESCRIPTION
## Summary

Project-level skill overrides for `start-session` and `end-session`, derived from the `/insights` 50-session friction analysis. Skills in `.claude/commands/` shadow the global `~/.claude/commands/` versions for this repo only.

## Friction → Amendment mapping

| Skill | Historical friction event | Amendment |
|---|---|---|
| `start-session` | Branched from non-main commit; user had to interrupt twice | Step 0: `git branch --show-current` check; hard-stop if not on `main` |
| `start-session` | Started file exploration before pulling latest main | Step 0: `git fetch origin && git pull origin main` required before any file reads |
| `start-session` | Branch was behind remote; Claude didn't notice | Step 0: pull is mandatory, not conditional on "behind" check |
| `end-session` | PR #26: Claude self-confirmed criteria as "code looks correct" | Step 2: CONFIRMED / INFERRED / UNVERIFIED labels; "code looks correct" explicitly excluded from CONFIRMED |
| `end-session` | Polling bug fix shipped without re-live-testing the fix | Step 2 re-test gate: live-discovered fixes are INFERRED until re-tested live |
| `end-session` | OAuth issue: partial criteria confirmed, one missed | Step 2 hard stop: ANY INFERRED or UNVERIFIED criterion blocks close until user replies |

## Validation

`scripts/validate_skill_amendments.py` simulates both gates against 7 historical failure scenarios. All 7 pass:

```
Results: 7/7 scenarios behave as expected
```

Run with: `python3 scripts/validate_skill_amendments.py`

## Also included

- `.claude/settings.local.json` and `.claude/worktrees/` added to `.gitignore` (personal session state was previously untracked but uncommitted)

## Test plan

- [ ] Run `python3 scripts/validate_skill_amendments.py` — should show 7/7
- [ ] Start a new session from a non-main branch and confirm Step 0 fires
- [ ] Run `/end-session` with an INFERRED criterion and confirm the hard-stop prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)