### PR TITLE
chore: gitignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ htmlcov/
 
 # macOS
 .DS_Store
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` so Claude Code session state (settings, worktrees, commands, plans) is never accidentally committed.

## Test plan
- [ ] Verify `.claude/` no longer appears in `git status` after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)