### PR TITLE
fix(#54): filter combat-only potions outside combat

### DIFF
--- a/game/options.py
+++ b/game/options.py
@@ -97,6 +97,10 @@ def potion_vote_entries(state: GameState) -> tuple[list[tuple[str, str]], list[t
                 # All other enemy-targeting potions require combat and are blocked here.
                 if not (p.get("id") == _FOUL_POTION_ID and state.state_type in ("shop", "fake_merchant")):
                     continue
+            elif not p.get("can_use_outside_combat", True):
+                # Combat-only potions with non-enemy target_type (e.g. Flex, Energy,
+                # Strength, Block Potion) would error if used outside combat.
+                continue
         use_entries.append((f"{POTION_USE_PREFIX}{p['slot'] + 1}", potion_display_name(p)))
     discard_entries: list[tuple[str, str]] = (
         [(f"{POTION_DISCARD_PREFIX}{p['slot'] + 1}", potion_display_name(p)) for p in state.player_potions]

--- a/tests/game/test_options.py
+++ b/tests/game/test_options.py
@@ -101,6 +101,47 @@ def test_discard_offered_in_eligible_states():
         assert "d1" in opts, f"Expected d1 in options for state_type={st!r}"
 
 
+# --- Combat-only potions (issue #54) ---
+
+def _potion_full(slot: int, name: str, target_type: str = "Self", in_combat: bool = True,
+                 out_of_combat: bool = True, potion_id: str = "") -> dict:
+    return {
+        "slot": slot,
+        "id": potion_id,
+        "name": name,
+        "target_type": target_type,
+        "can_use_in_combat": in_combat,
+        "can_use_outside_combat": out_of_combat,
+    }
+
+
+def test_out_of_combat_excludes_combat_only_self_target_potion():
+    # Flex Potion: target_type=Self but can_use_outside_combat=False
+    potions = [_potion_full(0, "Flex Potion", target_type="Self", out_of_combat=False)]
+    state = make_state("rewards", player_potions=potions)
+    opts = options_for_state(state)
+    assert "p1" not in opts
+
+
+def test_out_of_combat_keeps_anywhere_self_target_potion():
+    # Fruit Juice: target_type=Self, can_use_outside_combat=True
+    potions = [_potion_full(0, "Fruit Juice", target_type="Self", out_of_combat=True)]
+    state = make_state("rewards", player_potions=potions)
+    opts = options_for_state(state)
+    assert "p1" in opts
+
+
+def test_in_combat_keeps_both_combat_only_and_anywhere_potions():
+    potions = [
+        _potion_full(0, "Flex Potion", target_type="Self", in_combat=True, out_of_combat=False),
+        _potion_full(1, "Fruit Juice", target_type="Self", in_combat=True, out_of_combat=True),
+    ]
+    state = make_state("monster", playable_card_indices=[0], player_potions=potions)
+    opts = options_for_state(state)
+    assert "p1" in opts
+    assert "p2" in opts
+
+
 # --- Shop options ---
 
 def _shop_item(index: int, stocked: bool = True, afford: bool = True, category: str = "card") -> dict:


### PR DESCRIPTION
Closes #54

## Summary
Combat-only potions (Flex, Energy, Strength, Block) have `target_type: None/Self` and were not caught by the existing `_ENEMY_TARGET_TYPES` filter, so they were offered as `!pN` vote options outside combat. The bot recovered when the API rejected them, but the option should never have been offered. This change filters them in `potion_vote_entries` using the `can_use_outside_combat` field.

## Acceptance criteria
- [x] Combat-only potions (Flex, Energy, Strength, Block) do not appear as vote options outside combat
- [x] Usable-anywhere potions (Fruit Juice, Fairy in a Bottle) still appear outside combat
- [x] No behavioral change inside combat

## Tests
- \`test_out_of_combat_excludes_combat_only_self_target_potion\`
- \`test_out_of_combat_keeps_anywhere_self_target_potion\`
- \`test_in_combat_keeps_both_combat_only_and_anywhere_potions\`

237 passed (234 baseline + 3 new).