### PR TITLE
refactor(#92): extract shared HTTP retry/unwrap helper

### DIFF
--- a/game/_http.py
+++ b/game/_http.py
@@ -1,0 +1,69 @@
+"""Shared HTTP helpers for STS2Client and MenuClient.
+
+Both clients hit small local REST APIs with the same retry/unwrap shape:
+- Retry on httpx.ConnectError / TimeoutException with exponential backoff
+- Treat non-2xx as a soft failure (log + return None)
+- Return parsed JSON on success
+
+These helpers accept an explicit `logger` so each caller still logs under its
+own module name, preserving existing log-scraping behavior.
+"""
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+import httpx
+
+
+async def retry_request(
+    label: str,
+    coro_factory: Callable[[], Awaitable[httpx.Response]],
+    attempts: int,
+    backoff_seconds: float,
+    logger: logging.Logger,
+) -> httpx.Response | None:
+    """Execute coro_factory() with exponential backoff retry on transient failures.
+
+    Retries up to `attempts` times on ConnectError or TimeoutException.
+    Returns None when all attempts are exhausted.
+    """
+    for attempt in range(attempts + 1):
+        try:
+            return await coro_factory()
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            if attempt < attempts:
+                delay = backoff_seconds * (2 ** attempt)
+                logger.warning(
+                    "%s: transient error (%s) — retry %d/%d in %.1fs",
+                    label, type(exc).__name__, attempt + 1, attempts, delay,
+                )
+                await asyncio.sleep(delay)
+    return None
+
+
+async def fetch_json(
+    label: str,
+    bad_status_label: str,
+    coro_factory: Callable[[], Awaitable[httpx.Response]],
+    attempts: int,
+    backoff_seconds: float,
+    logger: logging.Logger,
+) -> dict | None:
+    """Call `coro_factory` with retry; return parsed JSON or None.
+
+    On non-2xx, logs a warning that includes `response.text` (the body) so both
+    GET and POST emit consistent diagnostics.
+    """
+    response = await retry_request(label, coro_factory, attempts, backoff_seconds, logger)
+    if response is None:
+        return None
+    if response.is_success:
+        return response.json()
+    logger.warning(
+        "%s returned status %s: %s",
+        bad_status_label,
+        response.status_code,
+        response.text,
+    )
+    return None

--- a/game/api_client.py
+++ b/game/api_client.py
@@ -1,8 +1,8 @@
-import asyncio
 import logging
-from collections.abc import Callable, Awaitable
 
 import httpx
+
+from game._http import fetch_json
 
 logger = logging.getLogger(__name__)
 
@@ -26,41 +26,16 @@ class STS2Client:
         """Close the underlying HTTP client."""
         await self._http.aclose()
 
-    async def _retry(
-        self,
-        label: str,
-        coro_factory: Callable[[], Awaitable[httpx.Response]],
-    ) -> httpx.Response | None:
-        """Execute coro_factory() with exponential backoff retry on transient failures.
-
-        Retries up to `http_retry_attempts` times on ConnectError or TimeoutException.
-        Returns None when all attempts are exhausted.
-        """
-        for attempt in range(self._http_retry_attempts + 1):
-            try:
-                return await coro_factory()
-            except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                if attempt < self._http_retry_attempts:
-                    delay = self._http_retry_backoff_seconds * (2 ** attempt)
-                    logger.warning(
-                        "%s: transient error (%s) — retry %d/%d in %.1fs",
-                        label, type(exc).__name__, attempt + 1, self._http_retry_attempts, delay,
-                    )
-                    await asyncio.sleep(delay)
-        return None
-
     async def get_state(self) -> dict | None:
         """Fetch current game state from STS2MCP. Returns parsed JSON or None on failure."""
-        response = await self._retry(
-            "STS2MCP GET",
-            lambda: self._http.get(f"{self._base_url}/api/v1/singleplayer"),
+        return await fetch_json(
+            label="STS2MCP GET",
+            bad_status_label="STS2MCP API",
+            coro_factory=lambda: self._http.get(f"{self._base_url}/api/v1/singleplayer"),
+            attempts=self._http_retry_attempts,
+            backoff_seconds=self._http_retry_backoff_seconds,
+            logger=logger,
         )
-        if response is None:
-            return None
-        if response.is_success:
-            return response.json()
-        logger.warning("STS2MCP API returned status %s", response.status_code)
-        return None
 
     async def post_action(self, body: dict) -> dict | None:
         """Submit a player action to STS2MCP. Returns parsed JSON or None on failure.
@@ -71,17 +46,11 @@ class STS2Client:
         if self.dry_run:
             logger.info("[DRY RUN] Skipping action: %s", body)
             return {"status": "ok", "message": f"[DRY RUN] {body}"}
-        response = await self._retry(
-            "STS2MCP POST",
-            lambda: self._http.post(f"{self._base_url}/api/v1/singleplayer", json=body),
+        return await fetch_json(
+            label="STS2MCP POST",
+            bad_status_label="STS2MCP action POST",
+            coro_factory=lambda: self._http.post(f"{self._base_url}/api/v1/singleplayer", json=body),
+            attempts=self._http_retry_attempts,
+            backoff_seconds=self._http_retry_backoff_seconds,
+            logger=logger,
         )
-        if response is None:
-            return None
-        if response.is_success:
-            return response.json()
-        logger.warning(
-            "STS2MCP action POST returned status %s: %s",
-            response.status_code,
-            response.text,
-        )
-        return None

--- a/game/menu_client.py
+++ b/game/menu_client.py
@@ -1,8 +1,8 @@
-import asyncio
 import logging
-from collections.abc import Callable, Awaitable
 
 import httpx
+
+from game._http import fetch_json
 
 logger = logging.getLogger(__name__)
 
@@ -24,41 +24,16 @@ class MenuClient:
         """Close the underlying HTTP client."""
         await self._http.aclose()
 
-    async def _retry(
-        self,
-        label: str,
-        coro_factory: Callable[[], Awaitable[httpx.Response]],
-    ) -> httpx.Response | None:
-        """Execute coro_factory() with exponential backoff retry on transient failures.
-
-        Retries up to `http_retry_attempts` times on ConnectError or TimeoutException.
-        Returns None when all attempts are exhausted.
-        """
-        for attempt in range(self._http_retry_attempts + 1):
-            try:
-                return await coro_factory()
-            except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                if attempt < self._http_retry_attempts:
-                    delay = self._http_retry_backoff_seconds * (2 ** attempt)
-                    logger.warning(
-                        "%s: transient error (%s) — retry %d/%d in %.1fs",
-                        label, type(exc).__name__, attempt + 1, self._http_retry_attempts, delay,
-                    )
-                    await asyncio.sleep(delay)
-        return None
-
     async def get_menu_state(self) -> dict | None:
         """Fetch current menu screen state from STS2-MenuControl. Returns parsed JSON or None on failure."""
-        response = await self._retry(
-            "MenuControl GET",
-            lambda: self._http.get(f"{self._base_url}/api/v1/menu"),
+        return await fetch_json(
+            label="MenuControl GET",
+            bad_status_label="MenuControl API",
+            coro_factory=lambda: self._http.get(f"{self._base_url}/api/v1/menu"),
+            attempts=self._http_retry_attempts,
+            backoff_seconds=self._http_retry_backoff_seconds,
+            logger=logger,
         )
-        if response is None:
-            return None
-        if response.is_success:
-            return response.json()
-        logger.warning("MenuControl API returned status %s", response.status_code)
-        return None
 
     async def post_menu_action(
         self, action: str, option_index: int | None = None
@@ -67,17 +42,11 @@ class MenuClient:
         body: dict = {"action": action}
         if option_index is not None:
             body["option_index"] = option_index
-        response = await self._retry(
-            "MenuControl POST",
-            lambda: self._http.post(f"{self._base_url}/api/v1/menu", json=body),
+        return await fetch_json(
+            label="MenuControl POST",
+            bad_status_label="MenuControl action POST",
+            coro_factory=lambda: self._http.post(f"{self._base_url}/api/v1/menu", json=body),
+            attempts=self._http_retry_attempts,
+            backoff_seconds=self._http_retry_backoff_seconds,
+            logger=logger,
         )
-        if response is None:
-            return None
-        if response.is_success:
-            return response.json()
-        logger.warning(
-            "MenuControl action POST returned status %s: %s",
-            response.status_code,
-            response.text,
-        )
-        return None

--- a/tests/game/test_http.py
+++ b/tests/game/test_http.py
@@ -1,0 +1,143 @@
+"""Tests for the shared HTTP helper in game/_http.py."""
+
+import logging
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from game._http import fetch_json, retry_request
+
+URL = "http://localhost:9999/thing"
+
+
+# --- retry_request ---
+
+async def test_retry_request_success_first_try(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=URL, json={"ok": True})
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        resp = await retry_request(
+            "TEST", lambda: http.get(URL), attempts=2, backoff_seconds=0.0, logger=logger
+        )
+    assert resp is not None
+    assert resp.status_code == 200
+
+
+async def test_retry_request_retries_then_succeeds(httpx_mock: HTTPXMock):
+    httpx_mock.add_exception(httpx.ConnectError("refused"))
+    httpx_mock.add_response(url=URL, json={"ok": True})
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        resp = await retry_request(
+            "TEST", lambda: http.get(URL), attempts=2, backoff_seconds=0.0, logger=logger
+        )
+    assert resp is not None
+    assert resp.status_code == 200
+
+
+async def test_retry_request_exhausts_returns_none(httpx_mock: HTTPXMock):
+    for _ in range(3):
+        httpx_mock.add_exception(httpx.ConnectError("refused"))
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        resp = await retry_request(
+            "TEST", lambda: http.get(URL), attempts=2, backoff_seconds=0.0, logger=logger
+        )
+    assert resp is None
+
+
+async def test_retry_request_timeout_also_retried(httpx_mock: HTTPXMock):
+    httpx_mock.add_exception(httpx.TimeoutException("timed out"))
+    httpx_mock.add_response(url=URL, json={"ok": True})
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        resp = await retry_request(
+            "TEST", lambda: http.get(URL), attempts=2, backoff_seconds=0.0, logger=logger
+        )
+    assert resp is not None
+
+
+async def test_retry_request_does_not_retry_on_non_2xx(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=URL, status_code=500, text="boom")
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        resp = await retry_request(
+            "TEST", lambda: http.get(URL), attempts=2, backoff_seconds=0.0, logger=logger
+        )
+    assert resp is not None
+    assert resp.status_code == 500
+    assert len(httpx_mock.get_requests()) == 1
+
+
+# --- fetch_json ---
+
+async def test_fetch_json_success(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(url=URL, json={"hello": "world"})
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        result = await fetch_json(
+            label="TEST",
+            bad_status_label="TEST API",
+            coro_factory=lambda: http.get(URL),
+            attempts=0,
+            backoff_seconds=0.0,
+            logger=logger,
+        )
+    assert result == {"hello": "world"}
+
+
+async def test_fetch_json_non_2xx_returns_none_and_logs_body(
+    httpx_mock: HTTPXMock, caplog: pytest.LogCaptureFixture
+):
+    httpx_mock.add_response(url=URL, status_code=400, text="bad request body")
+    async with httpx.AsyncClient() as http:
+        test_logger = logging.getLogger("game._http.test")
+        with caplog.at_level(logging.WARNING, logger="game._http.test"):
+            result = await fetch_json(
+                label="TEST",
+                bad_status_label="TEST API",
+                coro_factory=lambda: http.get(URL),
+                attempts=0,
+                backoff_seconds=0.0,
+                logger=test_logger,
+            )
+    assert result is None
+    # Standardized: GET and POST both log the response body
+    assert "bad request body" in caplog.text
+    assert "400" in caplog.text
+
+
+async def test_fetch_json_transient_failure_returns_none(httpx_mock: HTTPXMock):
+    httpx_mock.add_exception(httpx.ConnectError("refused"))
+    async with httpx.AsyncClient() as http:
+        logger = logging.getLogger("test")
+        result = await fetch_json(
+            label="TEST",
+            bad_status_label="TEST API",
+            coro_factory=lambda: http.get(URL),
+            attempts=0,
+            backoff_seconds=0.0,
+            logger=logger,
+        )
+    assert result is None
+
+
+async def test_fetch_json_uses_provided_logger(
+    httpx_mock: HTTPXMock, caplog: pytest.LogCaptureFixture
+):
+    """Verifies each client preserves its own logger name (not game._http)."""
+    httpx_mock.add_response(url=URL, status_code=500, text="oops")
+    named_logger = logging.getLogger("game.api_client.fake")
+    async with httpx.AsyncClient() as http:
+        with caplog.at_level(logging.WARNING, logger="game.api_client.fake"):
+            await fetch_json(
+                label="X",
+                bad_status_label="X API",
+                coro_factory=lambda: http.get(URL),
+                attempts=0,
+                backoff_seconds=0.0,
+                logger=named_logger,
+            )
+    # Confirm the record came from the caller-supplied logger
+    assert any(r.name == "game.api_client.fake" for r in caplog.records)


### PR DESCRIPTION
Closes #92

## Summary
`STS2Client` and `MenuClient` each carried a byte-identical `_retry` and near-identical GET/POST response-unwrap. Extracted to `game/_http.py` (`retry_request`, `fetch_json`). Both clients now delegate. Also standardised non-2xx body logging so GET behaves the same as POST.

## Behavior preservation
- Retry counts, backoff curve (\`backoff * 2**attempt\`), exception tuple (\`ConnectError, TimeoutException\`), and return shapes are identical to the originals.
- Each client passes its own logger so existing log scrapes remain valid.

## Acceptance criteria
- [x] One implementation of retry + response-unwrap
- [x] STS2Client and MenuClient delegate to the shared helper
- [x] GET and POST log non-2xx bodies consistently
- [x] No behavior change (existing 234 + 9 new tests pass)

## Tests added (9)
test_retry_request_success_first_try, test_retry_request_retries_then_succeeds, test_retry_request_exhausts_returns_none, test_retry_request_timeout_also_retried, test_retry_request_does_not_retry_on_non_2xx, test_fetch_json_success, test_fetch_json_non_2xx_returns_none_and_logs_body, test_fetch_json_transient_failure_returns_none, test_fetch_json_uses_provided_logger.

243 passed (234 baseline + 9 new) in 6.63s.