### PR TITLE
refactor(#94): decompose poll_game_state into pure helpers

### DIFF
--- a/game/polling.py
+++ b/game/polling.py
@@ -40,6 +40,199 @@ def _log_within_state_changes(prev: GameState, curr: GameState) -> None:
             )
 
 
+def detect_transition(prev: GameState | None, curr: GameState) -> GameEvent | None:
+    """Return the GameEvent triggered by a state_type transition (or initial state), or None.
+
+    Handles:
+      - Initial state (prev is None): menu → MenuSelectNeeded; actionable → VoteNeeded.
+      - state_type change: menu→non-menu → GameStarted; →game_over → GameEnded;
+        combat→overlay → GameEnded (death); →menu → MenuSelectNeeded;
+        →actionable → VoteNeeded; otherwise None.
+
+    Pure: no I/O, no side effects beyond a log line when no input is required.
+    """
+    if prev is None:
+        logger.info("Initial game state: %s", curr.summary())
+        if curr.state_type == "menu":
+            logger.info("Game is at main menu — queuing character select vote")
+            return MenuSelectNeededEvent()
+        if curr.requires_player_input():
+            logger.info("Queuing vote for initial state: %s", curr.state_type)
+            return VoteNeededEvent(curr)
+        return None
+
+    if curr.state_type == prev.state_type:
+        return None
+
+    logger.info("Game state changed: %s", curr.summary())
+    if prev.state_type == "menu" and curr.state_type != "menu":
+        return GameStartedEvent(curr)
+    if curr.state_type == "game_over":
+        return GameEndedEvent(curr)
+    if prev.is_combat_state() and curr.state_type == "overlay":
+        logger.info("Combat ended in overlay — treating as game ended")
+        return GameEndedEvent(curr)
+    if curr.state_type == "menu":
+        logger.info("Game is at main menu — queuing character select vote")
+        return MenuSelectNeededEvent()
+    if curr.requires_player_input():
+        logger.info("Queuing vote for state: %s", curr.state_type)
+        return VoteNeededEvent(curr)
+    logger.info("State '%s' does not require player input — no vote queued", curr.state_type)
+    return None
+
+
+def _mid_turn_change_reason(
+    prev: GameState,
+    curr: GameState,
+    action_signal: asyncio.Event | None,
+) -> str | None:
+    """Return which clause triggered the mid-turn re-queue, or None.
+
+    Reasons (checked in order):
+      - "action_signal": an action was just posted (guaranteed recheck).
+      - "hand_size": hand_size changed.
+      - "playable": set of playable card indices changed.
+      - "potions": a potion slot was consumed.
+      - "energy": player energy decreased.
+    """
+    if action_signal is not None and action_signal.is_set():
+        return "action_signal"
+    if (
+        curr.hand_size is not None
+        and prev.hand_size is not None
+        and curr.hand_size != prev.hand_size
+    ):
+        return "hand_size"
+    if set(curr.playable_card_indices) != set(prev.playable_card_indices):
+        return "playable"
+    if len(curr.player_potions) < len(prev.player_potions):
+        return "potions"
+    if (
+        curr.player_energy is not None
+        and prev.player_energy is not None
+        and curr.player_energy < prev.player_energy
+    ):
+        return "energy"
+    return None
+
+
+async def recheck_after_action(
+    client: STS2Client,
+    prev_state: GameState,
+    curr_state: GameState,
+    attempts: int,
+    interval: float,
+) -> tuple[GameState, GameEvent | None]:
+    """Poll briefly after an action to catch delayed state changes (e.g. Dagger Throw).
+
+    Returns (final_state, event_to_queue). The event is:
+      - VoteNeededEvent(final_state) if state_type changed and requires input,
+      - GameEndedEvent(final_state) if combat→overlay (death) during recheck,
+      - VoteNeededEvent(final_state) for plain mid-turn re-queue (state unchanged),
+      - None if final state doesn't require input and isn't a death overlay.
+    """
+    recheck_state = curr_state
+    for _ in range(attempts):
+        await asyncio.sleep(interval)
+        recheck_data = await client.get_state()
+        if not recheck_data:
+            break
+        try:
+            recheck_state = GameState.from_api_response(recheck_data)
+        except ValueError:
+            break
+        if recheck_state.state_type != curr_state.state_type:
+            break  # state changed — exit early
+
+    if recheck_state.state_type != curr_state.state_type:
+        logger.info(
+            "State changed to '%s' after card play — queuing directly",
+            recheck_state.state_type,
+        )
+        if recheck_state.requires_player_input():
+            return recheck_state, VoteNeededEvent(recheck_state)
+        if curr_state.is_combat_state() and recheck_state.state_type == "overlay":
+            logger.info("Combat ended in overlay after card play — treating as game ended")
+            return recheck_state, GameEndedEvent(recheck_state)
+        return recheck_state, None
+
+    logger.info(
+        "Mid-turn change (hand %s → %s, potions %d → %d) — re-queuing vote",
+        prev_state.hand_size,
+        recheck_state.hand_size,
+        len(prev_state.player_potions),
+        len(recheck_state.player_potions),
+    )
+    return recheck_state, VoteNeededEvent(recheck_state)
+
+
+async def _handle_within_state(
+    client: STS2Client,
+    prev: GameState,
+    curr: GameState,
+    event_queue: asyncio.Queue[GameEvent],
+    action_signal: asyncio.Event | None,
+    recheck_attempts: int,
+    recheck_interval: float,
+) -> GameState:
+    """Handle a poll where state_type is unchanged. Returns the state to store as previous."""
+    _log_within_state_changes(prev, curr)
+    logger.debug("Poll: same state '%s'", curr.state_type)
+
+    if curr.is_combat_state() and not curr.is_play_phase:
+        logger.debug("Combat '%s': enemy turn (is_play_phase=False)", curr.state_type)
+        return curr
+
+    if curr.is_combat_state() and curr.is_play_phase:
+        if not prev.is_play_phase:
+            logger.info("Player turn started (is_play_phase=True) — queuing vote")
+            event_queue.put_nowait(VoteNeededEvent(curr))
+            return curr
+        if (
+            curr.battle_round is not None
+            and prev.battle_round is not None
+            and curr.battle_round > prev.battle_round
+        ):
+            logger.info(
+                "New player turn detected (battle round %d → %d, enemy turn missed by poller) — queuing vote",
+                prev.battle_round,
+                curr.battle_round,
+            )
+            event_queue.put_nowait(VoteNeededEvent(curr))
+            return curr
+        reason = _mid_turn_change_reason(prev, curr, action_signal)
+        if reason is not None:
+            logger.info("mid-turn re-queue: %s", reason)
+            if action_signal is not None:
+                action_signal.clear()
+            final_state, event = await recheck_after_action(
+                client, prev, curr, recheck_attempts, recheck_interval
+            )
+            if event is not None:
+                event_queue.put_nowait(event)
+            return final_state
+        logger.debug(
+            "Combat '%s': player turn, no new-turn trigger (round=%s, hand=%s)",
+            curr.state_type,
+            curr.battle_round,
+            curr.hand_size,
+        )
+        return curr
+
+    if curr.state_type == "event":
+        curr_key = [(o.get("index"), o.get("title")) for o in curr.event_options]
+        prev_key = [(o.get("index"), o.get("title")) for o in prev.event_options]
+        if prev_key and curr_key != prev_key and curr.requires_player_input():
+            logger.info(
+                "Event options changed %s → %s — re-queuing vote",
+                [t for _, t in prev_key],
+                [t for _, t in curr_key],
+            )
+            event_queue.put_nowait(VoteNeededEvent(curr))
+    return curr
+
+
 async def poll_game_state(
     client: STS2Client,
     interval: float,
@@ -67,140 +260,16 @@ async def poll_game_state(
                 if state.state_type not in KNOWN_STATES.keys() | IDLE_STATES:
                     logger.info("UNKNOWN STATE: type=%s keys=%s", state.state_type, list(data.keys()))
 
-                if previous_state is None:
-                    # First successful poll — emit if input needed
-                    logger.info("Initial game state: %s", state.summary())
-                    if state.state_type == "menu":
-                        logger.info("Game is at main menu — queuing character select vote")
-                        event_queue.put_nowait(MenuSelectNeededEvent())
-                    elif state.requires_player_input():
-                        logger.info("Queuing vote for initial state: %s", state.state_type)
-                        event_queue.put_nowait(VoteNeededEvent(state))
+                if previous_state is None or state.state_type != previous_state.state_type:
+                    event = detect_transition(previous_state, state)
+                    if event is not None:
+                        event_queue.put_nowait(event)
                     previous_state = state
-
-                elif state.state_type != previous_state.state_type:
-                    # State transition
-                    logger.info("Game state changed: %s", state.summary())
-                    if previous_state.state_type == "menu" and state.state_type != "menu":
-                        event_queue.put_nowait(GameStartedEvent(state))
-                    elif state.state_type == "game_over":
-                        event_queue.put_nowait(GameEndedEvent(state))
-                    elif previous_state.is_combat_state() and state.state_type == "overlay":
-                        # Player died — defeat screen appears as overlay before/instead of game_over
-                        logger.info("Combat ended in overlay — treating as game ended")
-                        event_queue.put_nowait(GameEndedEvent(state))
-                    elif state.state_type == "menu":
-                        logger.info("Game is at main menu — queuing character select vote")
-                        event_queue.put_nowait(MenuSelectNeededEvent())
-                    elif state.requires_player_input():
-                        logger.info("Queuing vote for state: %s", state.state_type)
-                        event_queue.put_nowait(VoteNeededEvent(state))
-                    else:
-                        logger.info("State '%s' does not require player input — no vote queued", state.state_type)
-                    previous_state = state
-
                 else:
-                    # Same state_type — check for within-state changes
-                    _log_within_state_changes(previous_state, state)
-                    logger.debug("Poll: same state '%s'", state.state_type)
-                    if state.is_combat_state() and not state.is_play_phase:
-                        logger.debug("Combat '%s': enemy turn (is_play_phase=False)", state.state_type)
-                    elif state.is_combat_state() and state.is_play_phase:
-                        if not previous_state.is_play_phase:
-                            # Edge: enemy turn → player turn (caught by poller)
-                            logger.info(
-                                "Player turn started (is_play_phase=True) — queuing vote"
-                            )
-                            event_queue.put_nowait(VoteNeededEvent(state))
-                        elif (
-                            state.battle_round is not None
-                            and previous_state.battle_round is not None
-                            and state.battle_round > previous_state.battle_round
-                        ):
-                            # Enemy turn completed faster than the poll interval — both
-                            # snapshots have is_play_phase=True, but battle.round incremented,
-                            # which is a definitive signal that a new player turn started.
-                            logger.info(
-                                "New player turn detected (battle round %d → %d, enemy turn missed by poller) — queuing vote",
-                                previous_state.battle_round,
-                                state.battle_round,
-                            )
-                            event_queue.put_nowait(VoteNeededEvent(state))
-                        elif (
-                            (action_signal is not None and action_signal.is_set())
-                        ) or (
-                            state.hand_size is not None
-                            and previous_state.hand_size is not None
-                            and state.hand_size != previous_state.hand_size
-                        ) or (
-                            set(state.playable_card_indices) != set(previous_state.playable_card_indices)
-                        ) or (
-                            len(state.player_potions) < len(previous_state.player_potions)
-                        ) or (
-                            state.player_energy is not None
-                            and previous_state.player_energy is not None
-                            and state.player_energy < previous_state.player_energy
-                        ):
-                            # Action was just posted (guaranteed recheck), hand size changed,
-                            # playable cards changed, or a potion was consumed. Poll briefly before
-                            # re-queuing — some cards (e.g. Dagger Throw) or potions may trigger
-                            # hand_select after a short delay.
-                            if action_signal is not None:
-                                action_signal.clear()
-                            recheck_state = state
-                            for _ in range(recheck_attempts):
-                                await asyncio.sleep(recheck_interval)
-                                recheck_data = await client.get_state()
-                                if not recheck_data:
-                                    break
-                                try:
-                                    recheck_state = GameState.from_api_response(recheck_data)
-                                except ValueError:
-                                    break
-                                if recheck_state.state_type != state.state_type:
-                                    break  # state changed — exit early
-
-                            if recheck_state.state_type != state.state_type:
-                                # State already changed — queue new state directly, skip combat re-queue
-                                logger.info(
-                                    "State changed to '%s' after card play — queuing directly",
-                                    recheck_state.state_type,
-                                )
-                                if recheck_state.requires_player_input():
-                                    event_queue.put_nowait(VoteNeededEvent(recheck_state))
-                                elif state.is_combat_state() and recheck_state.state_type == "overlay":
-                                    logger.info("Combat ended in overlay after card play — treating as game ended")
-                                    event_queue.put_nowait(GameEndedEvent(recheck_state))
-                            else:
-                                logger.info(
-                                    "Mid-turn change (hand %s → %s, potions %d → %d) — re-queuing vote",
-                                    previous_state.hand_size,
-                                    recheck_state.hand_size,
-                                    len(previous_state.player_potions),
-                                    len(recheck_state.player_potions),
-                                )
-                                event_queue.put_nowait(VoteNeededEvent(recheck_state))
-                            # Update state so previous_state = state (line below) uses recheck_state
-                            state = recheck_state
-                        else:
-                            logger.debug(
-                                "Combat '%s': player turn, no new-turn trigger (round=%s, hand=%s)",
-                                state.state_type,
-                                state.battle_round,
-                                state.hand_size,
-                            )
-                    elif state.state_type == "event":
-                        curr_key = [(o.get("index"), o.get("title")) for o in state.event_options]
-                        prev_key = [(o.get("index"), o.get("title")) for o in previous_state.event_options]
-                        if prev_key and curr_key != prev_key and state.requires_player_input():
-                            logger.info(
-                                "Event options changed %s → %s — re-queuing vote",
-                                [t for _, t in prev_key],
-                                [t for _, t in curr_key],
-                            )
-                            event_queue.put_nowait(VoteNeededEvent(state))
-                    previous_state = state
-
+                    previous_state = await _handle_within_state(
+                        client, previous_state, state, event_queue,
+                        action_signal, recheck_attempts, recheck_interval,
+                    )
         except Exception:
             logger.error("Unexpected error in polling loop", exc_info=True)
         await asyncio.sleep(interval)

--- a/tests/game/test_polling.py
+++ b/tests/game/test_polling.py
@@ -2,7 +2,13 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
-from game.polling import poll_game_state
+from game.polling import (
+    poll_game_state,
+    detect_transition,
+    _mid_turn_change_reason,
+    recheck_after_action,
+)
+from game.state import GameState
 from game.events import VoteNeededEvent, MenuSelectNeededEvent, GameStartedEvent, GameEndedEvent
 
 
@@ -152,6 +158,146 @@ async def test_combat_new_round_detected_by_battle_round_increment():
     events = await _drain(client, q)
     vote_events = [e for e in events if isinstance(e, VoteNeededEvent)]
     assert len(vote_events) >= 2  # initial + new round
+
+
+def _state(state_type: str = "monster", **kwargs) -> GameState:
+    """Build a GameState with sensible defaults for helper tests."""
+    defaults = dict(
+        state_type=state_type,
+        act=None,
+        floor=None,
+        player_hp=None,
+        player_max_hp=None,
+    )
+    defaults.update(kwargs)
+    return GameState(**defaults)
+
+
+# --- detect_transition ---
+
+def test_detect_transition_initial_actionable_returns_vote():
+    curr = _state("monster")
+    ev = detect_transition(None, curr)
+    assert isinstance(ev, VoteNeededEvent)
+    assert ev.state is curr
+
+
+def test_detect_transition_initial_menu_returns_menu_select():
+    ev = detect_transition(None, _state("menu"))
+    assert isinstance(ev, MenuSelectNeededEvent)
+
+
+def test_detect_transition_initial_idle_returns_none():
+    assert detect_transition(None, _state("game_over")) is None
+
+
+def test_detect_transition_same_state_returns_none():
+    s = _state("map")
+    assert detect_transition(s, _state("map")) is None
+
+
+def test_detect_transition_menu_to_combat_returns_game_started():
+    ev = detect_transition(_state("menu"), _state("monster"))
+    assert isinstance(ev, GameStartedEvent)
+
+
+def test_detect_transition_to_game_over_returns_game_ended():
+    ev = detect_transition(_state("monster"), _state("game_over"))
+    assert isinstance(ev, GameEndedEvent)
+
+
+def test_detect_transition_combat_to_overlay_returns_game_ended():
+    ev = detect_transition(_state("monster"), _state("overlay"))
+    assert isinstance(ev, GameEndedEvent)
+
+
+def test_detect_transition_to_menu_returns_menu_select():
+    ev = detect_transition(_state("monster"), _state("menu"))
+    assert isinstance(ev, MenuSelectNeededEvent)
+
+
+def test_detect_transition_to_actionable_returns_vote():
+    ev = detect_transition(_state("monster"), _state("card_reward"))
+    assert isinstance(ev, VoteNeededEvent)
+
+
+def test_detect_transition_to_idle_non_overlay_returns_none():
+    # non-combat → unknown (idle): not game_over, prev not combat, no input needed
+    ev = detect_transition(_state("map"), _state("unknown"))
+    assert ev is None
+
+
+# --- _mid_turn_change_reason ---
+
+def test_mid_turn_reason_none_when_no_change():
+    prev = _state("monster", hand_size=3, playable_card_indices=[0, 1], player_potions=[], player_energy=3)
+    curr = _state("monster", hand_size=3, playable_card_indices=[0, 1], player_potions=[], player_energy=3)
+    assert _mid_turn_change_reason(prev, curr, None) is None
+
+
+def test_mid_turn_reason_action_signal():
+    prev = _state("monster", hand_size=3, player_energy=3)
+    curr = _state("monster", hand_size=3, player_energy=3)
+    sig = asyncio.Event()
+    sig.set()
+    assert _mid_turn_change_reason(prev, curr, sig) == "action_signal"
+
+
+def test_mid_turn_reason_hand_size():
+    prev = _state("monster", hand_size=3, player_energy=3)
+    curr = _state("monster", hand_size=2, player_energy=3)
+    assert _mid_turn_change_reason(prev, curr, None) == "hand_size"
+
+
+def test_mid_turn_reason_playable():
+    prev = _state("monster", hand_size=3, playable_card_indices=[0, 1], player_energy=3)
+    curr = _state("monster", hand_size=3, playable_card_indices=[0], player_energy=3)
+    assert _mid_turn_change_reason(prev, curr, None) == "playable"
+
+
+def test_mid_turn_reason_potions():
+    prev = _state("monster", hand_size=3, player_potions=[{"slot": 0}], player_energy=3)
+    curr = _state("monster", hand_size=3, player_potions=[], player_energy=3)
+    assert _mid_turn_change_reason(prev, curr, None) == "potions"
+
+
+def test_mid_turn_reason_energy():
+    prev = _state("monster", hand_size=3, player_energy=3)
+    curr = _state("monster", hand_size=3, player_energy=1)
+    assert _mid_turn_change_reason(prev, curr, None) == "energy"
+
+
+# --- recheck_after_action ---
+
+async def test_recheck_after_action_state_unchanged_returns_vote():
+    prev = _state("monster", hand_size=3, player_potions=[{"slot": 0}])
+    curr = _state("monster", hand_size=2, player_potions=[])
+    # Recheck polls return the same state_type
+    client = MagicMock()
+    client.get_state = AsyncMock(return_value={"state_type": "monster"})
+    final, event = await recheck_after_action(client, prev, curr, attempts=2, interval=0)
+    assert final.state_type == "monster"
+    assert isinstance(event, VoteNeededEvent)
+
+
+async def test_recheck_after_action_state_changed_to_overlay_returns_game_ended():
+    prev = _state("monster", hand_size=3)
+    curr = _state("monster", hand_size=2)
+    client = MagicMock()
+    client.get_state = AsyncMock(return_value={"state_type": "overlay"})
+    final, event = await recheck_after_action(client, prev, curr, attempts=2, interval=0)
+    assert final.state_type == "overlay"
+    assert isinstance(event, GameEndedEvent)
+
+
+async def test_recheck_after_action_state_changed_to_actionable_returns_vote():
+    prev = _state("monster", hand_size=3)
+    curr = _state("monster", hand_size=2)
+    client = MagicMock()
+    client.get_state = AsyncMock(return_value={"state_type": "card_reward"})
+    final, event = await recheck_after_action(client, prev, curr, attempts=2, interval=0)
+    assert final.state_type == "card_reward"
+    assert isinstance(event, VoteNeededEvent)
 
 
 async def test_combat_to_overlay_during_mid_turn_recheck_emits_game_ended():


### PR DESCRIPTION
Closes #94

## Summary
\`poll_game_state\` was a 150-line / 6-level-nested loop mixing API connectivity tracking, transition detection, mid-turn change detection, and a recheck sub-loop. Decomposed into pure helpers; orchestration loop is now **40 lines**.

## New helpers (in \`game/polling.py\`)
- \`detect_transition(prev, curr) -> GameEvent | None\` — covers initial-state and state_type transitions
- \`_mid_turn_change_reason(prev, curr, action_signal) -> str | None\` — returns \`"action_signal"\` / \`"hand_size"\` / \`"playable"\` / \`"potions"\` / \`"energy"\` / \`None\`, checked in the same order as the original or-chain
- \`async recheck_after_action(...)\` — async helper that polls briefly, then returns \`(final_state, event_to_queue)\`
- \`_handle_within_state(...)\` — private same-state branch consolidation

## New log line
\`logger.info("mid-turn re-queue: %s", reason)\` at the trigger site (per AC #3). Original \`"Mid-turn change (hand X→Y, potions X→Y) — re-queuing vote"\` log is preserved inside \`recheck_after_action\`.

## Acceptance criteria
- [x] poll_game_state is ≤ 60 lines of orchestration (now 40)
- [x] Transition detection, within-state diffing, and recheck are each in their own pure helper
- [x] Mid-turn re-queue logs include the reason that fired
- [x] No behavior change (existing 14 tests untouched + 19 new tests pass; full suite 253 passing, 234 baseline + 19 new)