### PR TITLE
refactor(#91): async hardening — track event-runner task, narrow polling except, fix task_done

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -27,6 +27,23 @@ _HELP_TEXT = (
 )
 
 
+def _log_event_runner_exit(task: asyncio.Task) -> None:
+    """done_callback for the event-runner task — surface unhandled exceptions.
+
+    Without this, a fire-and-forget `asyncio.create_task` swallows any exception
+    that escapes the inner coroutine (e.g. one raised before its `while True`),
+    leaving the bot running with no event runner and no log trace.
+    """
+    if task.cancelled():
+        logger.info("Event runner task cancelled")
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Event runner task exited with unhandled exception", exc_info=exc)
+    else:
+        logger.warning("Event runner task exited cleanly (unexpected)")
+
+
 def _format_state_announcement(state: GameState) -> str | None:
     """Return a one-line chat announcement for entering this state, or None to skip.
 
@@ -336,6 +353,7 @@ class TwitchBot(commands.Bot):
         self.broadcaster: twitchio.PartialUser | None = None
         self._ready = asyncio.Event()  # set in event_ready; gates _event_runner
         self._connected_once = False   # guards against double-announce on TwitchIO reconnect
+        self._event_runner_task: asyncio.Task | None = None
 
         # Announcement tracking — reset on GameEndedEvent so each run starts fresh.
         self._welcome_sent: bool = False
@@ -364,7 +382,10 @@ class TwitchBot(commands.Bot):
         )
         await self.subscribe_websocket(payload=payload, as_bot=True)
 
-        asyncio.create_task(self._event_runner(), name="event-runner")
+        self._event_runner_task = asyncio.create_task(
+            self._event_runner(), name="event-runner"
+        )
+        self._event_runner_task.add_done_callback(_log_event_runner_exit)
 
     async def _chat(self, message: str) -> None:
         await self.broadcaster.send_message(
@@ -440,9 +461,17 @@ class TwitchBot(commands.Bot):
         broadcaster = self.broadcaster
 
         while True:
+            logger.debug("Event runner: waiting for event (queue size=%d)", self._event_queue.qsize())
+            # Bind `event` only after a successful get(); task_done() must be
+            # paired with a successful get(), so the try/finally that calls it
+            # wraps *handling*, not the get itself.
             try:
-                logger.debug("Event runner: waiting for event (queue size=%d)", self._event_queue.qsize())
                 event: GameEvent = await self._event_queue.get()
+            except asyncio.CancelledError:
+                logger.info("Event runner cancelled")
+                raise
+
+            try:
                 logger.info("Event runner: processing %s", type(event).__name__)
 
                 if isinstance(event, GameStartedEvent):
@@ -466,18 +495,16 @@ class TwitchBot(commands.Bot):
                     await self._handle_menu_select(broadcaster)
                 elif isinstance(event, VoteNeededEvent):
                     fresh = await self._check_vote_dispatch(event.state)
-                    if fresh is None:
-                        continue
-                    fresh_event = event if fresh is event.state else VoteNeededEvent(fresh)
-                    if fresh.state_type == "rewards":
-                        await self._handle_rewards(broadcaster)
-                    elif fresh.card_select_screen_type == "select":
-                        await self._handle_card_remove_event(fresh_event, broadcaster)
-                    elif fresh.card_select_screen_type == "upgrade":
-                        await self._handle_smith_upgrade_event(fresh_event, broadcaster)
-                    else:
-                        await self._handle_vote_needed(fresh_event, broadcaster)
-
+                    if fresh is not None:
+                        fresh_event = event if fresh is event.state else VoteNeededEvent(fresh)
+                        if fresh.state_type == "rewards":
+                            await self._handle_rewards(broadcaster)
+                        elif fresh.card_select_screen_type == "select":
+                            await self._handle_card_remove_event(fresh_event, broadcaster)
+                        elif fresh.card_select_screen_type == "upgrade":
+                            await self._handle_smith_upgrade_event(fresh_event, broadcaster)
+                        else:
+                            await self._handle_vote_needed(fresh_event, broadcaster)
             except asyncio.CancelledError:
                 logger.info("Event runner cancelled")
                 raise

--- a/game/polling.py
+++ b/game/polling.py
@@ -233,6 +233,13 @@ async def _handle_within_state(
     return curr
 
 
+#: Number of consecutive unexpected exceptions tolerated in the polling loop
+#: before the loop escalates by re-raising. Keeps the bot from quietly logging
+#: the same error every interval forever when something genuinely broken happens
+#: (e.g. an upstream API change that breaks state parsing).
+POLL_MAX_CONSECUTIVE_FAILURES: int = 10
+
+
 async def poll_game_state(
     client: STS2Client,
     interval: float,
@@ -244,6 +251,7 @@ async def poll_game_state(
     """Poll STS2MCP every `interval` seconds and emit typed GameEvents on state transitions."""
     previous_state: GameState | None = None
     api_reachable: bool = True
+    consecutive_failures: int = 0
 
     while True:
         try:
@@ -270,6 +278,21 @@ async def poll_game_state(
                         client, previous_state, state, event_queue,
                         action_signal, recheck_attempts, recheck_interval,
                     )
+            consecutive_failures = 0
+        except asyncio.CancelledError:
+            raise
         except Exception:
-            logger.error("Unexpected error in polling loop", exc_info=True)
+            consecutive_failures += 1
+            logger.error(
+                "Unexpected error in polling loop (%d/%d consecutive)",
+                consecutive_failures,
+                POLL_MAX_CONSECUTIVE_FAILURES,
+                exc_info=True,
+            )
+            if consecutive_failures >= POLL_MAX_CONSECUTIVE_FAILURES:
+                logger.critical(
+                    "Polling loop hit %d consecutive failures — escalating",
+                    consecutive_failures,
+                )
+                raise
         await asyncio.sleep(interval)

--- a/tests/bot/test_event_runner_async_hardening.py
+++ b/tests/bot/test_event_runner_async_hardening.py
@@ -1,0 +1,157 @@
+"""Async-hardening tests for bot.client event-runner (issue #91).
+
+Covers:
+- _log_event_runner_exit surfaces unhandled exceptions via the logger
+  (replacing the old fire-and-forget create_task that silently swallowed them).
+- _log_event_runner_exit does NOT log an error for a CancelledError exit.
+- task_done() is NOT called when queue.get() raises (CancelledError during
+  shutdown must not double-mark the queue).
+- task_done() IS called exactly once per successfully-dequeued event,
+  including when handler code raises.
+"""
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bot.client import _log_event_runner_exit
+
+
+# --- _log_event_runner_exit callback ---
+
+def test_log_event_runner_exit_logs_unhandled_exception(caplog):
+    """An event-runner task that raised should be logged at ERROR."""
+    loop = asyncio.new_event_loop()
+    try:
+        async def boom() -> None:
+            raise RuntimeError("event-runner died early")
+
+        task = loop.create_task(boom())
+        # Drive the task to completion so it captures the exception.
+        with pytest.raises(RuntimeError):
+            loop.run_until_complete(task)
+
+        with caplog.at_level(logging.ERROR, logger="bot.client"):
+            _log_event_runner_exit(task)
+
+        assert any(
+            "Event runner task exited with unhandled exception" in rec.message
+            for rec in caplog.records
+        )
+    finally:
+        loop.close()
+
+
+def test_log_event_runner_exit_silent_on_cancellation(caplog):
+    """Cancellation is a normal shutdown path — must NOT log at ERROR."""
+    loop = asyncio.new_event_loop()
+    try:
+        async def forever() -> None:
+            await asyncio.sleep(3600)
+
+        task = loop.create_task(forever())
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            loop.run_until_complete(task)
+
+        with caplog.at_level(logging.DEBUG, logger="bot.client"):
+            _log_event_runner_exit(task)
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records == []
+    finally:
+        loop.close()
+
+
+# --- task_done semantics in the event-runner consumer loop ---
+
+class _GetRaisesQueue:
+    """Minimal asyncio.Queue stand-in whose get() always raises CancelledError
+    and which records every task_done() call so we can assert it was NOT called.
+    """
+
+    def __init__(self) -> None:
+        self.task_done_calls: int = 0
+
+    async def get(self):
+        raise asyncio.CancelledError()
+
+    def task_done(self) -> None:
+        self.task_done_calls += 1
+
+    def qsize(self) -> int:
+        return 0
+
+
+async def test_event_runner_does_not_call_task_done_when_get_raises():
+    """If queue.get() raises CancelledError, task_done() must NOT fire."""
+    from bot import client as bot_client
+
+    queue = _GetRaisesQueue()
+
+    # Build a bare object that satisfies the attributes _event_runner reads.
+    obj = MagicMock()
+    obj._event_queue = queue
+    obj._ready = asyncio.Event()
+    obj._ready.set()
+    obj.broadcaster = MagicMock()
+
+    coro = bot_client.TwitchBot._event_runner(obj)
+    with pytest.raises(asyncio.CancelledError):
+        await coro
+
+    assert queue.task_done_calls == 0, (
+        "task_done() must not be called when get() raised — "
+        "would double-mark the queue on shutdown."
+    )
+
+
+async def test_event_runner_calls_task_done_once_per_successful_get():
+    """A successfully-dequeued event must yield exactly one task_done() call,
+    even if the handler raises."""
+    from bot import client as bot_client
+    from game.events import VoteNeededEvent
+
+    # Use a real queue with one event, then a CancelledError to terminate.
+    real_queue: asyncio.Queue = asyncio.Queue()
+    state = MagicMock()
+    state.state_type = "monster"
+    state.card_select_screen_type = None
+    event = VoteNeededEvent(state)
+    real_queue.put_nowait(event)
+
+    task_done_calls = []
+    original_task_done = real_queue.task_done
+
+    def counting_task_done() -> None:
+        task_done_calls.append(1)
+        original_task_done()
+
+    original_get = real_queue.get
+    get_call_count = {"n": 0}
+
+    async def get_then_cancel():
+        get_call_count["n"] += 1
+        if get_call_count["n"] == 1:
+            return await original_get()
+        raise asyncio.CancelledError()
+
+    real_queue.get = get_then_cancel  # type: ignore[assignment]
+    real_queue.task_done = counting_task_done  # type: ignore[assignment]
+
+    obj = MagicMock()
+    obj._event_queue = real_queue
+    obj._ready = asyncio.Event()
+    obj._ready.set()
+    obj.broadcaster = MagicMock()
+    # Make the handler raise so we exercise the except-then-finally path.
+    obj._check_vote_dispatch = AsyncMock(side_effect=RuntimeError("handler boom"))
+
+    coro = bot_client.TwitchBot._event_runner(obj)
+    with pytest.raises(asyncio.CancelledError):
+        await coro
+
+    assert len(task_done_calls) == 1, (
+        f"Expected exactly one task_done() (one successful get), got {len(task_done_calls)}"
+    )

--- a/tests/game/test_polling_async_hardening.py
+++ b/tests/game/test_polling_async_hardening.py
@@ -1,0 +1,65 @@
+"""Async-hardening tests for game.polling (issue #91).
+
+Covers:
+- poll_game_state re-raises asyncio.CancelledError instead of swallowing it.
+- poll_game_state escalates (raises) after POLL_MAX_CONSECUTIVE_FAILURES
+  consecutive unexpected exceptions, rather than logging silently forever.
+- A single intermittent failure does NOT escalate (consecutive counter resets
+  on the next successful poll).
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from game import polling
+from game.events import VoteNeededEvent
+from game.polling import POLL_MAX_CONSECUTIVE_FAILURES, poll_game_state
+
+
+async def test_poll_game_state_reraises_cancelled_error():
+    """CancelledError from get_state must propagate, not be caught by except Exception."""
+    client = MagicMock()
+    client.get_state = AsyncMock(side_effect=asyncio.CancelledError())
+    queue: asyncio.Queue = asyncio.Queue()
+
+    with pytest.raises(asyncio.CancelledError):
+        await poll_game_state(client, 0, queue)
+
+
+async def test_poll_game_state_escalates_after_max_consecutive_failures():
+    """After POLL_MAX_CONSECUTIVE_FAILURES consecutive exceptions, the loop re-raises."""
+    client = MagicMock()
+    boom = RuntimeError("boom")
+    # Every call raises — should escalate on the Nth call.
+    client.get_state = AsyncMock(side_effect=boom)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await poll_game_state(client, 0, queue)
+
+    # Should have been called exactly POLL_MAX_CONSECUTIVE_FAILURES times before
+    # escalating (the Nth call's exception is the one re-raised).
+    assert client.get_state.call_count == POLL_MAX_CONSECUTIVE_FAILURES
+
+
+async def test_poll_game_state_resets_consecutive_failures_on_success():
+    """A single transient failure followed by success should NOT escalate."""
+    client = MagicMock()
+    # One failure, then successful polls forever (until CancelledError ends it).
+    successes_then_cancel = (
+        [RuntimeError("transient")]
+        + [{"state_type": "monster"}] * (POLL_MAX_CONSECUTIVE_FAILURES + 2)
+        + [asyncio.CancelledError()]
+    )
+    client.get_state = AsyncMock(side_effect=successes_then_cancel)
+    queue: asyncio.Queue = asyncio.Queue()
+
+    # Must raise CancelledError, NOT RuntimeError — counter reset after success.
+    with pytest.raises(asyncio.CancelledError):
+        await poll_game_state(client, 0, queue)
+
+    # A vote event should have been queued on the first successful poll.
+    assert not queue.empty()
+    first = queue.get_nowait()
+    assert isinstance(first, VoteNeededEvent)


### PR DESCRIPTION
Closes #91

## Summary
Three latent async correctness papercuts fixed in the two long-running coroutines.

- **Event-runner task tracking.** `setup_hook` now stores the task as `self._event_runner_task` and attaches a `done_callback` (`_log_event_runner_exit`) that logs unhandled exceptions at ERROR. `CancelledError` is silently honored (expected on shutdown).
- **Polling-loop hardening.** `poll_game_state` now re-raises `asyncio.CancelledError` and escalates by re-raising after `POLL_MAX_CONSECUTIVE_FAILURES = 10` consecutive unexpected exceptions instead of looping forever at INFO. The counter resets on any successful poll.
- **`_event_runner` task_done fix.** Restructured so `task_done()` only runs after a successful `queue.get()`. The `get` sits in its own `try/except CancelledError`, and the handling sits in a `try/finally` that pairs `task_done()` with the successful `get`.

## Behavior preservation
All three are no-ops in the happy path. Behavior only changes when an exception actually fires in one of these coroutines — which today is silently masked.

## Acceptance criteria
- [x] Event-runner task is stored and exceptions are surfaced via done_callback
- [x] Polling loop re-raises \`CancelledError\` and escalates on persistent failure
- [x] \`task_done()\` only runs when \`get()\` returned an event
- [x] No behavior change in the happy path
- [x] Existing tests pass (272 passed, includes 7 new tests for this change)

## Tests added (7)
- \`test_poll_game_state_reraises_cancelled_error\`
- \`test_poll_game_state_escalates_after_max_consecutive_failures\`
- \`test_poll_game_state_resets_consecutive_failures_on_success\`
- \`test_log_event_runner_exit_logs_unhandled_exception\`
- \`test_log_event_runner_exit_silent_on_cancellation\`
- \`test_event_runner_does_not_call_task_done_when_get_raises\`
- \`test_event_runner_calls_task_done_once_per_successful_get\`